### PR TITLE
Support Tizen 2.3

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <widget xmlns:tizen="http://tizen.org/ns/widgets" xmlns="http://www.w3.org/ns/widgets" id="http://jellyfin.org/Jellyfin" version="0.1.0" viewmodes="fullscreen">
     <access origin="*" subdomains="true"></access>
-    <tizen:application id="AprZAARz4r.Jellyfin" package="AprZAARz4r" required_version="3.0"/>
+    <tizen:application id="AprZAARz4r.Jellyfin" package="AprZAARz4r" required_version="2.3"/>
     <author href="http://jellyfin.org" email="apps@jellyfin.org">Jellyfin</author>
     <content src="index.html"/>
     <description>Jellyfin for Samsung Smart TV (Tizen).</description>


### PR DESCRIPTION
Change `required_version` to `2.3`, because now we know that app can be run on Tizen 2.3.
https://github.com/jellyfin/jellyfin-tizen/issues/11#issuecomment-630214055
https://github.com/jellyfin/jellyfin-tizen/issues/19#issuecomment-630644690
