### PR TITLE
Fix the search for an entry point

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,7 +47,7 @@ function modifyIndex() {
             this.head.appendChild(meta);
 
             // Search for injected main.bundle
-            let apploader = this.head.querySelector('script[src^=main]');
+            let apploader = this.querySelector('script[src^=main]');
 
             if (apploader) {
                 console.debug('Found injected main.bundle');


### PR DESCRIPTION
In 10.7 the entry point is in `body` and in `master` it is in `head`.