### PR TITLE
Add AppHost.screen function

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -8,6 +8,7 @@
     <feature name="http://tizen.org/feature/screen.size.all"/>
     <icon src="icon.png"/>
     <name>Jellyfin</name>
+    <tizen:privilege name="http://developer.samsung.com/privilege/productinfo"/>
     <tizen:privilege name="http://tizen.org/privilege/tv.inputdevice"/>
     <tizen:profile name="tv"/>
     <tizen:setting screen-orientation="auto-rotation" context-menu="enable" background-support="disable" encryption="disable" install-location="auto" hwkey-event="enable"/>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -91,6 +91,11 @@ function modifyIndex() {
 
             const injectTarget = apploader.parentNode;
 
+            // inject webapis.js
+            const webapis = this.createElement('script');
+            webapis.setAttribute('src', '$WEBAPIS/webapis/webapis.js');
+            injectTarget.insertBefore(webapis, apploader);
+
             // inject appMode script
             var appMode = this.createElement('script');
             appMode.text = 'window.appMode=\'cordova\';';


### PR DESCRIPTION
To limit transcoding profiles with maximum resolution: https://github.com/jellyfin/jellyfin-web/pull/3343

**Changes**
- Add Samsung WEBAPIS and `ProductInfo` privilege
- Add `AppHost.screen` function