### PR TITLE
Fix 'let' keyword usage

### DIFF
--- a/tizen.js
+++ b/tizen.js
@@ -54,7 +54,7 @@
 
         return new Promise(function (resolve) {
             tizen.systeminfo.getPropertyValue('DISPLAY', function (result) {
-                let devicePixelRatio = 1;
+                var devicePixelRatio = 1;
 
                 if (typeof webapis.productinfo.is8KPanelSupported === 'function' && webapis.productinfo.is8KPanelSupported()){
                     console.log("8K UHD is supported");


### PR DESCRIPTION
**Changes**
Use `var` instead of `let`.

**Issues**
`let` and `const` are not supported by older browsers.