### PR TITLE
Enable Tizen background support

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -11,5 +11,5 @@
     <tizen:privilege name="http://developer.samsung.com/privilege/productinfo"/>
     <tizen:privilege name="http://tizen.org/privilege/tv.inputdevice"/>
     <tizen:profile name="tv"/>
-    <tizen:setting screen-orientation="auto-rotation" context-menu="enable" background-support="disable" encryption="disable" install-location="auto" hwkey-event="enable"/>
+    <tizen:setting screen-orientation="auto-rotation" context-menu="enable" background-support="enable" encryption="disable" install-location="auto" hwkey-event="enable"/>
 </widget>


### PR DESCRIPTION
This PR enables background support for Tizen.

This is especially useful for other TV appliances such as Samsung Freestyle, where it is more common to temporarily switch to calibration screen and other sections. 