### PR TITLE
Fix missing fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ _Also look [Wiki](https://github.com/jellyfin/jellyfin-tizen/wiki)._
 ```sh
 cd jellyfin-web
 SKIP_PREPARE=1 npm ci --no-audit
-npm run build:production
+USE_SYSTEM_FONTS=1 npm run build:production
 ```
 
 > You should get `jellyfin-web/dist/` directory.
 
 > `SKIP_PREPARE=1` can be omitted for 10.9+.
+
+> `USE_SYSTEM_FONTS=1` is required to discard unused fonts and to reduce the size of the app. (Since Jellyfin Web 10.9)
 
 > Use `npm run build:development` if you want to debug the app.
 
@@ -61,6 +63,9 @@ JELLYFIN_WEB_DIR=../jellyfin-web/dist npm ci --no-audit
 > You should get `jellyfin-tizen/www/` directory.
 
 > The `JELLYFIN_WEB_DIR` environment variable can be used to override the location of `jellyfin-web`.
+
+> Add `DISCARD_UNUSED_FONTS=1` environment variable to discard unused fonts and to reduce the size of the app. (Until Jellyfin Web 10.9)  
+> Don't use it with Jellyfin Web 10.9+. Instead, use `USE_SYSTEM_FONTS=1` environment variable when building Jellyfin Web.
 
 If any changes are made to `jellyfin-web/dist/`, the `jellyfin-tizen/www/` directory will need to be rebuilt using the command above.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,12 +11,13 @@ var WEB_DIR = process.env.JELLYFIN_WEB_DIR || 'node_modules/jellyfin-web/dist';
 WEB_DIR = path.resolve(WEB_DIR);
 console.info('Using jellyfin-web from', WEB_DIR);
 
+const DISCARD_UNUSED_FONTS = !!process.env.DISCARD_UNUSED_FONTS;
+
 var paths = {
     assets: {
         src: [
             WEB_DIR + '/**/*',
-            '!' + WEB_DIR + '/index.html',
-            '!' + WEB_DIR + '/*.woff2'      // exclude Noto Sans fonts (not used)
+            '!' + WEB_DIR + '/index.html'
         ],
         dest: 'www/'
     },
@@ -35,7 +36,12 @@ function clean() {
 
 // Search for used fonts and add them to assets
 function searchFonts() {
+    if (!DISCARD_UNUSED_FONTS) return Promise.resolve('skipped');
+
     const assets = paths.assets.src;
+
+    assets.push('!' + WEB_DIR + '/*.woff2');
+
     return gulp.src(WEB_DIR + '/main*.js')
         .pipe(scan({
             term: /[a-z0-9._-]*\.woff2/gi,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "git+https://github.com/jellyfin/jellyfin-tizen.git"
   },
   "scripts": {
+    "build": "gulp",
     "postinstall": "gulp"
   },
   "devDependencies": {


### PR DESCRIPTION
**Changes**
- Rely on the new `USE_SYSTEM_FONTS` feature (Jellyfin Web).
- Add the `DISCARD_UNUSED_FONTS` environment variable to control the execution of `searchFonts`.
_Ideally it should detect 10.8, but I don't know how. There was an idea to find a single `script` (`main.bundle`) in `index.html` (now there are several), but that is also unreliable.
Or we could backport `USE_SYSTEM_FONTS` to 10.8_
