### PR TITLE
Added a visibility change event listener to reload the page

### DIFF
--- a/tizen.js
+++ b/tizen.js
@@ -179,6 +179,12 @@
         }
     };
 
+    window.addEventListener('visibilitychange', function () {
+        if (!document.hidden) {
+            window.location.reload();
+        }
+    });
+
     window.addEventListener('load', function () {
         tizen.tvinputdevice.registerKey('MediaPlay');
         tizen.tvinputdevice.registerKey('MediaPause');


### PR DESCRIPTION
Added a visibility change event listener to reload the page when it is brought back from a hidden state. This is useful when the TV is turned off and then turned on, but the application is not killed by the TV. The state of the main page becomes stale, and the latest updates to the video progress are not visible.