### PR TITLE
Add Wiki sync workflow trigger

### DIFF
--- a/.github/workflows/trigger-wiki-sync.yml
+++ b/.github/workflows/trigger-wiki-sync.yml
@@ -1,0 +1,20 @@
+name: Sync Wiki
+
+on:
+  push:
+    branches:
+      - wiki/master
+
+jobs:
+  trigger-wiki-sync:
+    name: Trigger Wiki sync in the main repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Wiki sync in the main repo
+        run: |
+          curl \
+            -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/wiki-sync.yml/dispatches \
+            -d '{"ref":"refs/heads/master"}'


### PR DESCRIPTION
Requires `.github/workflows/wiki-sync.yml` in the main repo. #250

**Changes**
Add Wiki sync workflow.