### PR TITLE
Fix `TypeError: Failed to construct 'Headers': No matching constructor signature.`

### DIFF
--- a/tizen.js
+++ b/tizen.js
@@ -3,6 +3,20 @@
 
     console.log('Tizen adapter');
 
+    if (window.Headers) {
+        try {
+            new window.Headers(undefined);
+        } catch (_) {
+            console.debug('patch \'Headers\' to accept \'undefined\'');
+
+            var _Headers = window.Headers;
+
+            window.Headers = function (init) {
+                return init ? new _Headers(init) : new _Headers();
+            }
+        }
+    }
+
     // Similar to jellyfin-web
     function generateDeviceId() {
         return btoa([navigator.userAgent, new Date().getTime()].join('|')).replace(/=/g, '1');


### PR DESCRIPTION
Affected platforms:
  - Tizen 3
  - Tizen 4

**Changes**
Patch `Headers` to accept `undefined`.

**Issues**
Fixes #260

webOS 4 has the same bug (`TypeError: Failed to construct 'Headers': No matching constructor signature.`), but it doesn't seem to use `Headers`.
So we need to fix it in web or wait for https://github.com/remix-run/react-router/pull/11148