### PR TITLE
Enable support for ultra-wide screens

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -7,6 +7,7 @@
     <description>Jellyfin for Samsung Smart TV (Tizen).</description>
     <feature name="http://tizen.org/feature/screen.size.all"/>
     <icon src="icon.png"/>
+    <tizen:metadata key="http://tizen.org/metadata/app_ui_type/base_screen_resolution" value="fullscreen"/>
     <name>Jellyfin</name>
     <tizen:privilege name="http://developer.samsung.com/privilege/productinfo"/>
     <tizen:privilege name="http://tizen.org/privilege/tv.inputdevice"/>


### PR DESCRIPTION
According to https://developer.samsung.com/smarttv/develop/guides/base_screen_resolution.html

**Changes**
Enable support for ultra-wide screens.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-tizen/issues/231