### PR TITLE
 Add Samsung Smart Hub Preview Integration

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -22,10 +22,6 @@
     <name>Jellyfin</name>
     <tizen:privilege name="http://developer.samsung.com/privilege/productinfo"/>
     <tizen:privilege name="http://tizen.org/privilege/tv.inputdevice"/>
-    <tizen:privilege name="http://tizen.org/privilege/externalstorage.appdata"/>
-    <tizen:privilege name="http://tizen.org/privilege/mediastorage"/>
-    <tizen:privilege name="http://tizen.org/privilege/filesystem.read"/>
-    <tizen:privilege name="http://tizen.org/privilege/filesystem.write"/>
     <tizen:metadata key="http://samsung.com/tv/metadata/use.preview" value="bg_service"/>
     <tizen:profile name="tv"/>
     <tizen:setting screen-orientation="auto-rotation" context-menu="enable" background-support="disable" encryption="disable" install-location="auto" hwkey-event="enable"/>

--- a/config.xml
+++ b/config.xml
@@ -8,9 +8,25 @@
     <feature name="http://tizen.org/feature/screen.size.all"/>
     <icon src="icon.png"/>
     <tizen:metadata key="http://tizen.org/metadata/app_ui_type/base_screen_resolution" value="fullscreen"/>
+    <tizen:app-control>
+        <tizen:src name="index.html" reload="disable"/>
+        <tizen:operation name="http://samsung.com/appcontrol/operation/eden_resume"/>
+    </tizen:app-control>
+    <tizen:service id="AprZAARz4r.service">
+        <tizen:content src="service/service.js"/>
+        <tizen:name>jellyfin_service</tizen:name>
+        <tizen:description>Jellyfin Smarthub Preview Handler Service</tizen:description>
+        <tizen:metadata key="meta-key" value="meta-value"/>
+        <tizen:category name="http://tizen.org/category/service"/>
+    </tizen:service>
     <name>Jellyfin</name>
     <tizen:privilege name="http://developer.samsung.com/privilege/productinfo"/>
     <tizen:privilege name="http://tizen.org/privilege/tv.inputdevice"/>
+    <tizen:privilege name="http://tizen.org/privilege/externalstorage.appdata"/>
+    <tizen:privilege name="http://tizen.org/privilege/mediastorage"/>
+    <tizen:privilege name="http://tizen.org/privilege/filesystem.read"/>
+    <tizen:privilege name="http://tizen.org/privilege/filesystem.write"/>
+    <tizen:metadata key="http://samsung.com/tv/metadata/use.preview" value="bg_service"/>
     <tizen:profile name="tv"/>
     <tizen:setting screen-orientation="auto-rotation" context-menu="enable" background-support="disable" encryption="disable" install-location="auto" hwkey-event="enable"/>
 </widget>

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -107,13 +107,6 @@ function modifyIndex() {
             appMode.text = 'window.appMode=\'cordova\';';
             injectTarget.insertBefore(appMode, apploader);
 
-
-            // inject smarthub.js
-            const smarthub = this.createElement('script');
-            smarthub.setAttribute('src', '../smarthub.js');
-            smarthub.setAttribute('defer', '');
-            injectTarget.insertBefore(smarthub, apploader);
-
             // inject tizen.js
             const tizen = this.createElement('script');
             tizen.setAttribute('src', '../tizen.js');

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -107,6 +107,13 @@ function modifyIndex() {
             appMode.text = 'window.appMode=\'cordova\';';
             injectTarget.insertBefore(appMode, apploader);
 
+
+            // inject smarthub.js
+            const smarthub = this.createElement('script');
+            smarthub.setAttribute('src', '../smarthub.js');
+            smarthub.setAttribute('type', 'module');
+            injectTarget.insertBefore(smarthub, apploader);
+
             // inject tizen.js
             const tizen = this.createElement('script');
             tizen.setAttribute('src', '../tizen.js');

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -111,7 +111,7 @@ function modifyIndex() {
             // inject smarthub.js
             const smarthub = this.createElement('script');
             smarthub.setAttribute('src', '../smarthub.js');
-            smarthub.setAttribute('type', 'module');
+            smarthub.setAttribute('defer', '');
             injectTarget.insertBefore(smarthub, apploader);
 
             // inject tizen.js

--- a/service/service.js
+++ b/service/service.js
@@ -1,50 +1,19 @@
 var packageId = tizen.application.getCurrentApplication().appInfo.packageId;
 var applicationId = packageId + '.Jellyfin'
 var remoteMessagePort = undefined;
-var localMessagePort = undefined;
-var watchId = undefined;
-var isServiceStarted = false;
+
 
 /**
- * Handles incoming messages from the local message port.
+ * Sends a message to Application and write out the log.
+ * It is needed because logs are not visible from service
  *
- * @param {Array} data - Array of key-value pairs received via the message port.
- * @param {Object} remoteMsgPort - The remote message port instance that sent the message.
+ * @param {string} value - The value to send in the message and wite to console
  */
-
-function onReceived(data, remoteMsgPort) {
-
-    sendMessage("Key0 " + data[0].key)
-
-    if (data[0].key == "Preview") {
-
-        var previewData = data[0].value;
-        sendMessage("Preview Data recieved:" + previewData)
-        var previewData2 = JSON.parse(previewData);
-
-        try {
-            webapis.preview.setPreviewData(JSON.stringify(previewData2),
-                function () {
-                    console.log('Preview Set!');
-                    sendMessage("Preview Set!")
-                    // please terminate service after setting preview data
-                    tizen.application.getCurrentApplication().exit();
-                },
-                function (e) {
-                    console.log('PreviewData Setting failed : ' + e.message);
-                    sendMessage('PreviewData Setting failed : ' + e.message)
-                }
-            );
-        }
-        catch (e) {
-            sendMessage('PreviewData Setting exception : ' + e.message)
-            console.log('PreviewData Setting failed : ' + e.message);
-        }
-
-
-    }
-}; 
-
+function logAndSend(value)
+{
+    console.log(value);
+    sendMessage(value);
+}
 
 /**
  * Sends a message to the remote message port.
@@ -59,7 +28,7 @@ function sendMessage(value, key) {
     }
     if (remoteMessagePort ) {
         try {
-        remoteMessagePort .sendMessage([{ key, value }]);
+        remoteMessagePort.sendMessage([{ key, value }]);
     } catch (e) {
         console.error("Error sending message:", e.message);
     }
@@ -69,97 +38,64 @@ function sendMessage(value, key) {
 
 }
 
-/**
- * Starts the service by setting up a local message port and listener.
- */
-function start() {
-    if (isServiceStarted) {
-        console.log("Service already started.");
-        sendMessage("Service already started.")
-        return;
-    }
-        try {
-            sendMessage("Service Started:" + packageId )
-
-            localMessagePort  = tizen.messageport.requestLocalMessagePort(packageId);
-            watchId = localMessagePort.addMessagePortListener(onReceived);
-
-            /* For debugging purposes, somehow it is not working on the emulator. */
-            sendMessage("WatchID :" + watchId)
-            isServiceStarted = true;
-            console.log("Service started successfully.");
-            sendMessage("Service started successfully.");
-
-        }
-        catch (e) {
-            sendMessage("Creating of local port not sucessfull: " + e.message)
-            console.log("Creating of local port not sucessfull: " + e.message);
-        }
-    
-}
-
-
 function handleDataInRequest()
 {
     try {
-       
         var reqAppControl = tizen.application.getCurrentApplication().getRequestedAppControl();
+
         if (!!reqAppControl) {
+            var appControlData = reqAppControl.appControl.data;
 
-            if (reqAppControl.appControl.data[0].key == 'Preview') {
-                var previewData = reqAppControl.appControl.data[0].value;
-                var previewData2 = JSON.parse(previewData);
-                sendMessage("Preview Data recieved:" + previewData)
+            // Iterate through all keys in appControl.data
+            for (var i = 0; i < appControlData.length; i++) {
+                var key = appControlData[i].key;
+                var value = appControlData[i].value;
 
-                try {
-                    webapis.preview.setPreviewData(JSON.stringify(previewData2),
-                        function () {
-                            console.log('setPreviewData SuccessCallback');
-                            // please terminate service after setting preview data
-                            sendMessage("Preview Set!")
-                            tizen.application.getCurrentApplication().exit();
-                        },
-                        function (e) {
-                            console.log('PreviewData Setting failed : ' + e.message);
-                            sendMessage('PreviewData Setting failed : ' + e.message)
-                        }
-                    );
-                }
-                catch (e) {
-                    sendMessage('PreviewData Setting exception : ' + e.message)
+                if (key === 'Preview') {
+                    var previewData = value;
+                    var previewData2 = JSON.parse(previewData);
+                    logAndSend("Preview Data received: " + previewData);
+
+                    try {
+                        webapis.preview.setPreviewData(
+                            JSON.stringify(previewData2),
+                            function () {
+                                logAndSend("Preview Set!");
+                                tizen.application.getCurrentApplication().exit();
+                            },
+                            function (e) {
+                                logAndSend("PreviewData Setting failed: " + e.message);
+                            }
+                        );
+                    } catch (e) {
+                        logAndSend("PreviewData Setting exception: " + e.message);
+                    }
+                } else {
+                    logAndSend("Unhandled key: " + key + ", value: " + value);
                 }
             }
-   
         }
-        else
-        {
-            sendMessage('Unknown Request ')
-        }  
     }
     catch (e) {
-        sendMessage('On error exception : ' + e.message)
+        logAndSend('On error exception : ' + e.message);
     }
 }
 
 module.exports.onStart = function () {
-    start();
-    sendMessage("OnStart recieved")
+    logAndSend('OnStart recieved');
+    handleDataInRequest();
 };
 
 module.exports.onRequest = function () {
-        start();
-        sendMessage("onRequest recieved");
-        handleDataInRequest();
+    logAndSend('onRequest recieved');
 }
 
 
 module.exports.onStop = function () {
-    console.log("Service stopping...");
-    sendMessage("Service stopping...");
+    logAndSend('Service stopping...');
 };
 
 
 module.exports.onExit = function () {
-    console.log("Service exiting...");
-    sendMessage("Service exiting...");
+    logAndSend("Service exiting...");
 } 

--- a/service/service.js
+++ b/service/service.js
@@ -83,11 +83,11 @@ function handleDataInRequest()
 
 module.exports.onStart = function () {
     logAndSend('OnStart recieved');
-    handleDataInRequest();
 };
 
 module.exports.onRequest = function () {
     logAndSend('onRequest recieved');
+    handleDataInRequest();
 }
 
 

--- a/service/service.js
+++ b/service/service.js
@@ -1,0 +1,107 @@
+var pkg_id = 'AprZAARz4r'
+var app_id = 'AprZAARz4r.Jellyfin'
+var remote_message_port = undefined;
+var local_message_port = undefined;
+//var message_port_listener = undefined;
+var watchId = undefined;
+
+function onReceived(data, remoteMsgPort) {
+
+    /*remote_message_port = tizen.messageport.requestRemoteMessagePort(app_id, "AprZAARz4r.DataChannel");
+    const dataa = [{key: "KEY", value: "Valasz"}];
+    remote_message_port.sendMessage(dataa);*/
+    //console.log('onReceived : ' + JSON.stringify(data) + ' remotePort : ' + remoteMsgPort);
+    sendMessage("KEY", "Recieved!!!!!!")
+    console.log("service start");
+};
+
+function sendMessage(key, value) {
+    if (remote_message_port === undefined) {
+        remote_message_port = tizen.messageport.requestRemoteMessagePort(app_id, "AprZAARz4r.DataChannel");
+    }
+    remote_message_port.sendMessage([{ key, value }]);
+    console.error("Message port is undefined");
+
+}
+
+module.exports.onStart = function () {
+    //console.log("onStart is called");
+    //pkg_id = tizen.application.getCurrentApplication().appInfo.packageId;
+    //app_id = tizen.application.getCurrentApplication().appInfo.id;
+
+    try {
+        if (remote_message_port === undefined) {
+            remote_message_port = tizen.messageport.requestRemoteMessagePort(app_id, "AprZAARz4r.DataChannel");
+        }
+        sendMessage("KEY", "Service Started with id:" + pkg_id)
+
+        try {
+            local_message_port = tizen.messageport.requestLocalMessagePort("CHANNEL2");
+            watchId = local_message_port.addMessagePortListener(onReceived);
+            sendMessage("KEY", "WatchID :" + watchId)
+        }
+        catch (e) {
+            sendMessage("KEY", "Error " + e.message)
+            //const data4 = [{ key: "KEY", value: "Error" + e.message }];
+            //remote_message_port.sendMessage(data4);
+        }
+
+    }
+    catch (e) {
+        sendMessage("KEY", "Error " + e.message)
+    }
+
+};
+
+module.exports.onRequest = function () {
+    try {
+        console.log('Request Callback');
+        var reqAppControl = tizen.application.getCurrentApplication().getRequestedAppControl();
+        if (!!reqAppControl) {
+
+            if (reqAppControl.appControl.data[0].key == 'Preview') {
+                var previewData = reqAppControl.appControl.data[0].value;
+                var previewData2 = JSON.parse(previewData);
+                sendMessage("KEY", "Preview Data recieved:" + previewData)
+
+                try {
+                    webapis.preview.setPreviewData(JSON.stringify(previewData2),
+                        function () {
+                            console.log('setPreviewData SuccessCallback');
+                            // please terminate service after setting preview data
+                            sendMessage("KEY", "Preview Set!")
+                            tizen.application.getCurrentApplication().exit();
+                        },
+                        function (e) {
+                            console.log('PreviewData Setting failed : ' + e.message);
+                            sendMessage("KEY", 'PreviewData Setting failed : ' + e.message)
+                        }
+                    );
+                }
+                catch (e) {
+                    sendMessage("KEY", 'PreviewData Setting exception : ' + e.message)
+                }
+            }
+            local_message_port = tizen.messageport.requestLocalMessagePort("CHANNEL2");
+            watchId = local_message_port.addMessagePortListener(onReceived);
+        }
+        else {
+            sendMessage("KEY", 'Unknown Request ')
+        }
+    }
+    catch (e) {
+        sendMessage("KEY", 'On error exception : ' + e.message)
+    }
+}
+
+
+module.exports.onStop = function () {
+    console.log("onStop is called");
+    sendMessage("KEY", 'on Stop: : ')
+};
+
+
+module.exports.onExit = function () {
+    console.log("onExit is callback");
+    sendMessage("KEY", 'Exit Callback')
+} 

--- a/service/service.js
+++ b/service/service.js
@@ -1,6 +1,6 @@
-var packageId  = tizen.application.getCurrentApplication().appInfo.packageId;
-var applicationId = packageId +'.Jellyfin'
-var remoteMessagePort  = undefined;
+var packageId = tizen.application.getCurrentApplication().appInfo.packageId;
+var applicationId = packageId + '.Jellyfin'
+var remoteMessagePort = undefined;
 var localMessagePort = undefined;
 var watchId = undefined;
 var isServiceStarted = false;
@@ -11,6 +11,7 @@ var isServiceStarted = false;
  * @param {Array} data - Array of key-value pairs received via the message port.
  * @param {Object} remoteMsgPort - The remote message port instance that sent the message.
  */
+
 function onReceived(data, remoteMsgPort) {
 
     sendMessage("Key0 " + data[0].key)
@@ -42,7 +43,8 @@ function onReceived(data, remoteMsgPort) {
 
 
     }
-};
+}; 
+
 
 /**
  * Sends a message to the remote message port.
@@ -53,7 +55,7 @@ function onReceived(data, remoteMsgPort) {
 function sendMessage(value, key) {
     key = key || "KEY";
     if (remoteMessagePort  === undefined) {
-        remoteMessagePort  = tizen.messageport.requestRemoteMessagePort(applicationId, "DATACHANNEL");
+        remoteMessagePort  = tizen.messageport.requestRemoteMessagePort(applicationId, packageId);
     }
     if (remoteMessagePort ) {
         try {
@@ -73,18 +75,20 @@ function sendMessage(value, key) {
 function start() {
     if (isServiceStarted) {
         console.log("Service already started.");
+        sendMessage("Service already started.")
         return;
     }
         try {
             sendMessage("Service Started:" + packageId )
 
-            localMessagePort  = tizen.messageport.requestLocalMessagePort("DATACHANNEL");
+            localMessagePort  = tizen.messageport.requestLocalMessagePort(packageId);
             watchId = localMessagePort.addMessagePortListener(onReceived);
 
             /* For debugging purposes, somehow it is not working on the emulator. */
             sendMessage("WatchID :" + watchId)
             isServiceStarted = true;
             console.log("Service started successfully.");
+            sendMessage("Service started successfully.");
 
         }
         catch (e) {
@@ -94,13 +98,58 @@ function start() {
     
 }
 
+
+function handleDataInRequest()
+{
+    try {
+       
+        var reqAppControl = tizen.application.getCurrentApplication().getRequestedAppControl();
+        if (!!reqAppControl) {
+
+            if (reqAppControl.appControl.data[0].key == 'Preview') {
+                var previewData = reqAppControl.appControl.data[0].value;
+                var previewData2 = JSON.parse(previewData);
+                sendMessage("Preview Data recieved:" + previewData)
+
+                try {
+                    webapis.preview.setPreviewData(JSON.stringify(previewData2),
+                        function () {
+                            console.log('setPreviewData SuccessCallback');
+                            // please terminate service after setting preview data
+                            sendMessage("Preview Set!")
+                            tizen.application.getCurrentApplication().exit();
+                        },
+                        function (e) {
+                            console.log('PreviewData Setting failed : ' + e.message);
+                            sendMessage('PreviewData Setting failed : ' + e.message)
+                        }
+                    );
+                }
+                catch (e) {
+                    sendMessage('PreviewData Setting exception : ' + e.message)
+                }
+            }
+   
+        }
+        else
+        {
+            sendMessage('Unknown Request ')
+        }  
+    }
+    catch (e) {
+        sendMessage('On error exception : ' + e.message)
+    }
+}
+
 module.exports.onStart = function () {
     start();
+    sendMessage("OnStart recieved")
 };
 
-
 module.exports.onRequest = function () {
-    start();
+        start();
+        sendMessage("onRequest recieved");
+        handleDataInRequest();
 }
 
 

--- a/smarthub.js
+++ b/smarthub.js
@@ -149,7 +149,7 @@
    */
   var OnReceived = function (ui_data) {
     console.log("Received Data from Service : " + ui_data[0].value);
-    if (ui_data[0].value == 'Service stopping...'){
+    if (ui_data[0].value == 'Service stopping...' || ui_data[0].value == 'Service exiting...'){
       window.smartHubUpdated = true;
       localMessagePort.removeMessagePortListener(messagePortListener);
 

--- a/smarthub.js
+++ b/smarthub.js
@@ -17,12 +17,8 @@
 function getTileImageUrl(item) {
   item = item.ProgramInfo || item;
 
-  options ={
-    preferThumb: true,
-    inheritThumb: true,
-  }
-
-  preferThumb = true;
+  let preferThumb = true;
+  let inheritThumb = true;
   let height = 250;
   let imgUrl = null;
   let imgTag = null;
@@ -30,22 +26,22 @@ function getTileImageUrl(item) {
   let itemId = null;
 
   /* eslint-disable sonarjs/no-duplicated-branches */
-  if (options.preferThumb && item.ImageTags && item.ImageTags.Thumb) {
+  if (preferThumb && item.ImageTags && item.ImageTags.Thumb) {
       imgType = 'Thumb';
       imgTag = item.ImageTags.Thumb;
-  } else if (options.preferThumb && item.SeriesThumbImageTag && options.inheritThumb !== false) {
+  } else if (preferThumb && item.SeriesThumbImageTag && inheritThumb !== false) {
       imgType = 'Thumb';
       imgTag = item.SeriesThumbImageTag;
       itemId = item.SeriesId;
-  } else if (options.preferThumb && item.ParentThumbItemId && options.inheritThumb !== false && item.MediaType !== 'Photo') {
+  } else if (preferThumb && item.ParentThumbItemId && inheritThumb !== false && item.MediaType !== 'Photo') {
       imgType = 'Thumb';
       imgTag = item.ParentThumbImageTag;
       itemId = item.ParentThumbItemId;
-  } else if (options.preferThumb && item.BackdropImageTags && item.BackdropImageTags.length) {
+  } else if (preferThumb && item.BackdropImageTags && item.BackdropImageTags.length) {
       imgType = 'Backdrop';
       imgTag = item.BackdropImageTags[0];
       forceName = true;
-  } else if (options.preferThumb && item.ParentBackdropImageTags && item.ParentBackdropImageTags.length && options.inheritThumb !== false && item.Type === 'Episode') {
+  } else if (preferThumb && item.ParentBackdropImageTags && item.ParentBackdropImageTags.length && inheritThumb !== false && item.Type === 'Episode') {
       imgType = 'Backdrop';
       imgTag = item.ParentBackdropImageTags[0];
       itemId = item.ParentBackdropItemId;
@@ -89,15 +85,15 @@ function getTileImageUrl(item) {
   } else if (item.ImageTags && item.ImageTags.Thumb) {
       imgType = 'Thumb';
       imgTag = item.ImageTags.Thumb;
-  } else if (item.SeriesThumbImageTag && options.inheritThumb !== false) {
+  } else if (item.SeriesThumbImageTag && inheritThumb !== false) {
       imgType = 'Thumb';
       imgTag = item.SeriesThumbImageTag;
       itemId = item.SeriesId;
-  } else if (item.ParentThumbItemId && options.inheritThumb !== false) {
+  } else if (item.ParentThumbItemId && inheritThumb !== false) {
       imgType = 'Thumb';
       imgTag = item.ParentThumbImageTag;
       itemId = item.ParentThumbItemId;
-  } else if (item.ParentBackdropImageTags && item.ParentBackdropImageTags.length && options.inheritThumb !== false) {
+  } else if (item.ParentBackdropImageTags && item.ParentBackdropImageTags.length && inheritThumb !== false) {
       imgType = 'Backdrop';
       imgTag = item.ParentBackdropImageTags[0];
       itemId = item.ParentBackdropItemId;

--- a/smarthub.js
+++ b/smarthub.js
@@ -48,10 +48,6 @@ function getTileImageUrl(item) {
   } else if (item.ImageTags && item.ImageTags.Primary && (item.Type !== 'Episode' || item.ChildCount !== 0)) {
       imgType = 'Primary';
       imgTag = item.ImageTags.Primary;
-
-      if (primaryImageAspectRatio && uiAspect) {
-          coverImage = (Math.abs(primaryImageAspectRatio - uiAspect) / uiAspect) <= 0.2;
-      }
   } else if (item.SeriesPrimaryImageTag) {
       imgType = 'Primary';
       imgTag = item.SeriesPrimaryImageTag;
@@ -60,10 +56,6 @@ function getTileImageUrl(item) {
       imgType = 'Primary';
       imgTag = item.PrimaryImageTag;
       itemId = item.PrimaryImageItemId;
-
-      if (primaryImageAspectRatio && uiAspect) {
-          coverImage = (Math.abs(primaryImageAspectRatio - uiAspect) / uiAspect) <= 0.2;
-      }
   } else if (item.ParentPrimaryImageTag) {
       imgType = 'Primary';
       imgTag = item.ParentPrimaryImageTag;
@@ -72,10 +64,6 @@ function getTileImageUrl(item) {
       imgType = 'Primary';
       imgTag = item.AlbumPrimaryImageTag;
       itemId = item.AlbumId;
-
-      if (primaryImageAspectRatio && uiAspect) {
-          coverImage = (Math.abs(primaryImageAspectRatio - uiAspect) / uiAspect) <= 0.2;
-      }
   } else if (item.Type === 'Season' && item.ImageTags && item.ImageTags.Thumb) {
       imgType = 'Thumb';
       imgTag = item.ImageTags.Thumb;

--- a/smarthub.js
+++ b/smarthub.js
@@ -1,4 +1,3 @@
-/*(function () {*/
 
   var packageId = tizen.application.getCurrentApplication().appInfo.packageId;
   var serviceId = packageId + ".service";
@@ -7,79 +6,17 @@
   var localMessagePort = undefined;
   var messagePortListener = undefined;
 
-  var localJsonData = {
-    "sections": [
-            {
-                "title": "Next Up",
-                "tiles": [
-                    {
-                        "title": "S11:E2 - 2. epizód",
-                        "subtitle": "Hívják a bábát",
-                        "image_ratio": "16by9",
-                        "image_url": "http://192.168.31.62:8096/Items/5f6a38a4adfd66d4d3e838f0bb19e050/Images/Backdrop?format=jpg&quality=96&fillHeight=250",
-                        "action_data": "{\"serverid\":\"4513d1afddd14932aa9cbddc0756cc87\",\"id\":\"65073997942266eccaf61c0e745c9f38\"}",
-                        "is_playable": true
-                    },
-                    {
-                        "title": "S8:E22 - The Proposal",
-                        "subtitle": "The Goldbergs (2013)",
-                        "image_ratio": "16by9",
-                        "image_url": "http://192.168.31.62:8096/Items/263cf89eb8bbfd0cf58f66daa421af38/Images/Backdrop?format=jpg&quality=96&fillHeight=250&percentPlayed=10.541836545589325",
-                        "action_data": "{\"serverid\":\"4513d1afddd14932aa9cbddc0756cc87\",\"id\":\"328b67745026c24c82bbeaf4ce569b9b\"}",
-                        "is_playable": true
-                    }
-                ]
-            },
-            {
-                "title": "Continue Watching",
-                "tiles": [
-                    {
-                        "title": "Men in Black - Sötét zsaruk 2.",
-                        "image_ratio": "16by9",
-                        "image_url": "http://192.168.31.62:8096/Items/7e149af90e93f9d3036529486862100f/Images/Thumb?format=jpg&quality=96&fillHeight=250&percentPlayed=58.40761698414322",
-                        "action_data": "{\"serverid\":\"4513d1afddd14932aa9cbddc0756cc87\",\"id\":\"7e149af90e93f9d3036529486862100f\"}",
-                        "is_playable": true
-                    },
-                    {
-                        "title": "S2:E10 - 10. epizód",
-                        "subtitle": "Psych - Dilis detektívek",
-                        "image_ratio": "16by9",
-                        "image_url": "http://192.168.31.62:8096/Items/019cf831e3a7cdf5bfaa3c968b3b5e93/Images/Backdrop?format=jpg&quality=96&fillHeight=250&percentPlayed=21.214575024153394",
-                        "action_data": "{\"serverid\":\"4513d1afddd14932aa9cbddc0756cc87\",\"id\":\"9bf364266aa530d637284d680a26516e\"}",
-                        "is_playable": true
-                    },
-                    {
-                        "title": "S4:E6 - Recipe for Death II: Kiss the Cook",
-                        "subtitle": "The Goldbergs (2013)",
-                        "image_ratio": "16by9",
-                        "image_url": "http://192.168.31.62:8096/Items/263cf89eb8bbfd0cf58f66daa421af38/Images/Backdrop?format=jpg&quality=96&fillHeight=250&percentPlayed=17.31943792713447",
-                        "action_data": "{\"serverid\":\"4513d1afddd14932aa9cbddc0756cc87\",\"id\":\"05d927035a6dcf525770dd46dcfaa21f\"}",
-                        "is_playable": true
-                    },
-                    {
-                        "title": "S8:E22 - The Proposal",
-                        "subtitle": "The Goldbergs (2013)",
-                        "image_ratio": "16by9",
-                        "image_url": "http://192.168.31.62:8096/Items/263cf89eb8bbfd0cf58f66daa421af38/Images/Backdrop?format=jpg&quality=96&fillHeight=250&percentPlayed=10.541836545589325",
-                        "action_data": "{\"serverid\":\"4513d1afddd14932aa9cbddc0756cc87\",\"id\":\"328b67745026c24c82bbeaf4ce569b9b\"}",
-                        "is_playable": true
-                    }
-                ]
-            }
-        ]
-};
-
-
+  
 /**
  * Creates a JSON object representing one title for the smart view.
  * 
  * @param {Object} title_data - The title data containing details about the media items.
  * @param {string} title_data.ServerId - The server ID associated with the media.
- * @param {string} title_data.Id - The unique ID of the media item.
- * @param {number} title_data.ParentIndexNumber - The parent index number of the media.
+ * @param {string} title_data.Id - The unique ID of the "Episode"
+ * @param {number} title_data.ParentIndexNumber - The "Series" index number of the media.
  * @param {number} title_data.IndexNumber - The index number of the media.
- * @param {string} title_data.Name - The name of the media item.
- * @param {string} title_data.SeriesName - The series name of the media item.
+ * @param {string} title_data.Name - The name of the Movie
+ * @param {string} title_data.SeriesName - The name of the Series
  * @param {string} title_data.ParentBackdropItemId - The ID for the backdrop image.
  * @param {Object} title_data.UserData - User-specific data, including played percentage.
  * @param {number} title_data.UserData.PlayedPercentage - Percentage of the media played.
@@ -169,11 +106,12 @@
 
 
   /**
-   * Launches the Tizen application control to start a service
+   * Launches the Tizen application and send Smartview data
    * 
+   * @param {Object} smartViewJsonData - The title data containing details about the media items.
    * @throws {Error} Logs any error encountered during the service launch process.
   */
-  function startService(smartViewJsonData) {
+  function startServiceAndUpdateSmartView(smartViewJsonData) {
     console.log('Starting Service'),
     localMessagePort = tizen.messageport.requestLocalMessagePort(packageId);
     messagePortListener = localMessagePort.addMessagePortListener(OnReceived);
@@ -199,46 +137,30 @@
 
 
   /**
-   * Sends a key-value message to the Tizen service using the message port.
-   * 
-   * @param {string} key - The key for the message.
-   * @param {string} value - The value for the message.
-   */
-  function sendMessageToService(key, value) {
-    if (remoteMessagePort === undefined) {
-      remoteMessagePort = tizen.messageport.requestRemoteMessagePort(serviceId, packageId);
-    }
-
-    if (remoteMessagePort) {
-      remoteMessagePort.sendMessage([{ key, value }]);
-    }
-    else {
-      console.error("Message port is undefined");
-    }
-  }
-
-
-  /**
-   * Sends a smart view update request to the service.
-   * 
-   * @param {Object} smartViewJsonData - The smart view data to send.
-  */
-  function sendSmartViewUpdateRequest(smartViewJsonData) {
-    sendMessageToService('Preview', JSON.stringify(smartViewJsonData));
-
-  }
-
-
-  /**
    * Callback function for receiving messages from the Tizen service.
    * 
    * @param {Array<Object>} ui_data - The received data array from the service.
    */
   var OnReceived = function (ui_data) {
-    console.log("Received Data in Service : " + ui_data[0].value);
-    if (ui_data[0].value == 'Service exiting...')
-      window.scriptReady = true;
+    console.log("Received Data from Service : " + ui_data[0].value);
+    if (ui_data[0].value == 'Service stopping...'){
+      window.smartHubUpdated = true;
+      localMessagePort.removeMessagePortListener(messagePortListener);
+
+    }
   };
+
+  const waitForSmartHubUpdate = () => {
+    return new Promise((resolve) => {
+        const interval = setInterval(() => {
+            if (window.smartHubUpdated === true) {
+                clearInterval(interval); 
+                resolve(); 
+            }
+        }, 100); 
+    });
+};
+
 
 
   /**
@@ -251,14 +173,15 @@
     return new Promise(resolve => setTimeout(resolve, time));
   }
 
-
-
-
-  var interval = setInterval(function () {
+  (async function runSmartViewUpdater() {
   
-    if (typeof ApiClient == 'undefined') return;
-    clearInterval(interval);
-    const fetchData = async () => {
+    while (typeof ApiClient === 'undefined') {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+  
+
+    const runSmartViewUpdate = async () => {
+      window.smartHubUpdated = false;
       try {
         const [resumableItems, nextUpEpisodes] = await Promise.all([
           ApiClient.getResumableItems(ApiClient.getCurrentUserId()),
@@ -266,26 +189,36 @@
         ]);
   
         // Generate smart view data
-        smartViewJsonData = generateSmartViewJson([
+        const smartViewJsonData = generateSmartViewJson([
           { section_title: "Next Up", limit: 2, data: nextUpEpisodes.Items },
           { section_title: "Continue Watching", limit: 4, data: resumableItems.Items }
         ]);
+  
         console.log("Generated SmartViewResult: \n" + JSON.stringify(smartViewJsonData));
+  
         // Delay and send the smart view update request
         await delay(2000);
-        startService(smartViewJsonData);
-        //sendSmartViewUpdateRequest(smartViewJsonData);
+        startServiceAndUpdateSmartView(smartViewJsonData);
+        await waitForSmartHubUpdate();
+  
       } catch (error) {
         console.error("Error fetching data: ", error);
-        window.scriptReady = true;
+        window.smartHubUpdated = true;
       }
     };
   
-    // Start the service and fetch the data
-    fetchData();
+    window.runSmartViewUpdate = runSmartViewUpdate;
+    
+    // Refresh SmartView every 10min.
+    while (true) {
+      const startTime = Date.now();
+  
+      await runSmartViewUpdate();
+  
+      const elapsedTime = Date.now() - startTime;
+      const remainingTime = Math.max(600000 - elapsedTime, 0);
+      await new Promise(resolve => setTimeout(resolve, remainingTime));
+    }
+  })();
 
-  }, 1000);
 
-/*
-}
-)();*/

--- a/smarthub.js
+++ b/smarthub.js
@@ -43,6 +43,11 @@
     }
     
     if(title_data.Type =="Episode"){
+
+      action_data.type = 'episode';
+      action_data.seasonid = title_data.SeasonId;
+      action_data.seriesid = title_data.SeriesId;
+
       title = {
       title: "S" + title_data.ParentIndexNumber + ":E" + title_data.IndexNumber + " - " + title_data.Name,
       subtitle: title_data.SeriesName,
@@ -52,6 +57,7 @@
       is_playable: true
     };}
     else if(title_data.Type =="Movie"){
+      action_data.type = 'movie';
       title = {
         title: title_data.Name,
         image_ratio: "16by9",

--- a/smarthub.js
+++ b/smarthub.js
@@ -1,140 +1,227 @@
-/*(
+(function () {
 
-  function () {
-    'use strict';
-*/
-import { Service } from 'wrt:service';
+  var packageId = tizen.application.getCurrentApplication().appInfo.packageId;
+  var serviceId = packageId + ".service";
+  var smartViewJsonData = undefined;
+  var remoteMessagePort = undefined;
 
-var pkg_id = tizen.application.getCurrentApplication().appInfo.packageId;
-var service_id = pkg_id + ".service";
-var localJsonData = undefined;
+/**
+ * Creates a JSON object representing one title for the smart view.
+ * 
+ * @param {Object} title_data - The title data containing details about the media items.
+ * @param {string} title_data.ServerId - The server ID associated with the media.
+ * @param {string} title_data.Id - The unique ID of the media item.
+ * @param {number} title_data.ParentIndexNumber - The parent index number of the media.
+ * @param {number} title_data.IndexNumber - The index number of the media.
+ * @param {string} title_data.Name - The name of the media item.
+ * @param {string} title_data.SeriesName - The series name of the media item.
+ * @param {string} title_data.ParentBackdropItemId - The ID for the backdrop image.
+ * @param {Object} title_data.UserData - User-specific data, including played percentage.
+ * @param {number} title_data.UserData.PlayedPercentage - Percentage of the media played.
+ * @returns {Object|null} The formatted title JSON object or `null` if data is invalid.
+ */
+  function generateTitleJson(title_data) {
+
+    if (!title_data) {
+      console.warn("Missing title_data");
+      return null;
+    }
+
+    var action_data =
+    {
+      serverid: title_data.ServerId,
+      id: title_data.Id
+    };
+    var title = null;
+
+    var playedPercentage = "";
+
+    if (title_data.UserData && title_data.UserData.PlayedPercentage) {
+      playedPercentage = "&percentPlayed=" + title_data.UserData.PlayedPercentage;
+    }
+    
+    if(title_data.Type =="Episode"){
+      title = {
+      title: "S" + title_data.ParentIndexNumber + ":E" + title_data.IndexNumber + " - " + title_data.Name,
+      subtitle: title_data.SeriesName,
+      image_ratio: "16by9",
+      image_url: ApiClient.serverAddress() + "/Items/" + title_data.ParentBackdropItemId + "/Images/Backdrop?format=jpg&quality=96&fillHeight=250" + playedPercentage,
+      action_data: JSON.stringify(action_data),
+      is_playable: true
+    };}
+    else if(title_data.Type =="Movie"){
+      title = {
+        title: title_data.Name,
+        image_ratio: "16by9",
+        image_url: ApiClient.serverAddress() +"/Items/" + title_data.Id + "/Images/Thumb?format=jpg&quality=96&fillHeight=250" + playedPercentage,
+        action_data: JSON.stringify(action_data),
+        is_playable: true
+      };
+    }
+    return title;
+  }
 
 
-function create_title_json(title_data) {
+/**
+ * Creates a JSON object for the smart view containing multiple sections and their tiles.
+ * 
+ * @param {Array<Object>} sectionsData - Array of objects representing each section's metadata and content.
+ * @param {string} sectionsData[].section_title - Title of the section (e.g., "Next Up", "Continue Watching").
+ * @param {number} sectionsData[].limit - Maximum number of items to include in the section.
+ * @param {Array<Object>} sectionsData[].data - Array of media items to populate the section's tiles.
+ * 
+ * @returns {Object} A JSON object with `sections` for the smart view.
+ *                   Each section contains a title and an array of tiles.
+ *                   If no valid sections are provided, the returned object will have an empty `sections` array.
+ */
+  function generateSmartViewJson(sectionsData) {
+ 
 
-  var action_data =
-  {
-    serverid: title_data.ServerId,
-    id: title_data.Id
-  };
+    // Validate input data
+    if (!Array.isArray(sectionsData) || sectionsData.length === 0) {
+      console.warn("Invalid or empty sections data.");
+      return { sections: [] };
+    }
 
+     // Initialize the smart view JSON object
+    var smart_view_json = { sections: [] };
 
-  var obj = {
-    title: "S"+title_data.ParentIndexNumber+":E"+title_data.IndexNumber+" - "+title_data.Name,
-    subtitle: "Subtitle",
-    image_ratio: "1by1",
-    image_url: "https://artworks.thetvdb.com/banners/fanart/original/78901-80.jpg",
-    //image_url: "http://192.168.31.62:8096/Items/5f6a38a4adfd66d4d3e838f0bb19e050/Images/Thumb?fillHeight=122&fillWidth=216&format=jpg&quality=96&tag=3e557bd01b366b69311d41a555d2bd96",
-    action_data: JSON.stringify(action_data), // Escaped JSON string
-    is_playable: true
-  };
-  return obj
-}
-
-function create_smart_view_json(data) {
-  var obj = {
-    sections: [
-      {
-        title: "Ajanlott",
-        tiles: [create_title_json(data[0])]
-      },
-      {
-        title: "Folytasd",
-        tiles: [
-          create_title_json(data[1]),
-          create_title_json(data[2]),
-          create_title_json(data[3]),
-          create_title_json(data[4]),
-        ]
+     // Populate Sections
+     sectionsData.forEach(section => {
+      if (Array.isArray(section.data) && section.data.length > 0) {
+        const tiles = section.data.slice(0, section.limit).map(generateTitleJson).filter(Boolean);
+        if (tiles.length > 0) {
+          smart_view_json.sections.push({
+            title: section.section_title,
+            tiles: tiles
+          });
+        }
       }
-    ]
-  };
-  return obj
-}
+    });
 
-function send_message_to_service() {
+      return smart_view_json;
+    }
 
-  try {
-    tizen.application.launchAppControl(
-      new tizen.ApplicationControl(
-        'http://tizen.org/appcontrol/operation/pick',
-        null,
-        'image/jpeg',
-        null,
-        [
-          new tizen.ApplicationControlData('caller', [JSON.stringify(localJsonData)]),
-          new tizen.ApplicationControlData('Preview', [JSON.stringify(localJsonData)])
-        ]
-      ),
-      service_id,
-      () => console.log('Message: ' + JSON.stringify(localJsonData) + ' sent to ' + service_id),
-      (error) => console.error('Launch failed:', error.message)
-    );
-  } catch (error) {
-    console.error("Error sending message:", error);
+
+  /**
+   * Launches the Tizen application control to start a service
+   * 
+   * @throws {Error} Logs any error encountered during the service launch process.
+  */
+  function startService() {
+    try {
+      tizen.application.launchAppControl(
+        new tizen.ApplicationControl(
+          'http://tizen.org/appcontrol/operation/pick',
+          null,
+          'image/jpeg',
+          null,
+          [
+            new tizen.ApplicationControlData('caller', ["JSON.stringify(smartViewJsonData)"]),
+            new tizen.ApplicationControlData('Preview', ["JSON.stringify(smartViewJsonData)"])
+          ]
+        ),
+        serviceId,
+        () => console.log('Message sent to ' + serviceId),
+        (error) => console.error('Launch failed:', error.message)
+      );
+    } catch (error) {
+      console.error("Error sending message:", error);
+    }
+  }
+
+
+  /**
+   * Sends a key-value message to the Tizen service using the message port.
+   * 
+   * @param {string} key - The key for the message.
+   * @param {string} value - The value for the message.
+   */
+  function sendMessageToService(key, value) {
+    if (remoteMessagePort === undefined) {
+      remoteMessagePort = tizen.messageport.requestRemoteMessagePort(serviceId, "DATACHANNEL");
+    }
+
+    if (remoteMessagePort) {
+      remoteMessagePort.sendMessage([{ key, value }]);
+    }
+    else {
+      console.error("Message port is undefined");
+    }
+  }
+
+
+  /**
+   * Sends a smart view update request to the service.
+   * 
+   * @param {Object} smartViewJsonData - The smart view data to send.
+  */
+  function sendSmartViewUpdateRequest(smartViewJsonData) {
+    sendMessageToService('Preview', JSON.stringify(smartViewJsonData));
 
   }
-}
 
 
-var OnReceived = function (ui_data) {
-  console.log("Received Data in Service : " + ui_data[0].value);
-};
-
-function delay(time) {
-  return new Promise(resolve => setTimeout(resolve, time));
-}
-
-
-var local_message_port = tizen.messageport.requestLocalMessagePort(pkg_id + ".DataChannel");
-var message_port_listener = local_message_port.addMessagePortListener(OnReceived);
-
-
-var interval = setInterval(function () {
-  // get elem
-  if (typeof ApiClient == 'undefined') return;
-  clearInterval(interval);
-  const address = ApiClient.getResumableItems(ApiClient.getCurrentUserId())
-    .then((response) => {
-      return response.Items;
-    });
-
-  const printAddress = async () => {
-    const a = await address;
-
-    console.log(JSON.stringify(create_smart_view_json(a)));
-    localJsonData = create_smart_view_json(a);
-
-    delay(2000).then(() => {
-      console.log('ran after 2 second1 passed');
-      send_message_to_service(localJsonData);
-    });
-
-    /*delay(6000).then(() => {
-      console.log('ran after 6 second1 passed');
-      send_message_to_service(localJsonData);
-    });*/
+  /**
+   * Callback function for receiving messages from the Tizen service.
+   * 
+   * @param {Array<Object>} ui_data - The received data array from the service.
+   */
+  var OnReceived = function (ui_data) {
+    console.log("Received Data in Service : " + ui_data[0].value);
+    if (ui_data[0].value == 'Service exiting...')
+      window.scriptReady = true;
   };
 
 
-  var my_service = new Service(service_id);
-  my_service.start().then(function () {
-    console.log("Succeeded to start service333");
-  },
-    function (error) {
-      console.log("Failed to start service: " + error);
-
-    });
-
-  printAddress();
-
-
-
-
-  // the rest of the code
-}, 1000);
-
-/*
+  /**
+   * Delays execution for a specified time.
+   * 
+   * @param {number} time - Time in milliseconds to delay.
+   * @returns {Promise} A promise that resolves after the specified delay.
+   */
+  function delay(time) {
+    return new Promise(resolve => setTimeout(resolve, time));
   }
+
+
+  var localMessagePort = tizen.messageport.requestLocalMessagePort("DATACHANNEL");
+  localMessagePort.addMessagePortListener(OnReceived);
+
+
+  var interval = setInterval(function () {
+  
+    if (typeof ApiClient == 'undefined') return;
+    clearInterval(interval);
+    const fetchData = async () => {
+      try {
+        const [resumableItems, nextUpEpisodes] = await Promise.all([
+          ApiClient.getResumableItems(ApiClient.getCurrentUserId()),
+          ApiClient.getNextUpEpisodes(ApiClient.getCurrentUserId())
+        ]);
+  
+        // Generate smart view data
+        smartViewJsonData = generateSmartViewJson([
+          { section_title: "Next Up", limit: 2, data: nextUpEpisodes.Items },
+          { section_title: "Continue Watching", limit: 4, data: resumableItems.Items }
+        ]);
+        console.log("Generated SmartViewResult: \n" + JSON.stringify(smartViewJsonData));
+  
+        // Delay and send the smart view update request
+        await delay(2000);
+        sendSmartViewUpdateRequest(smartViewJsonData);
+      } catch (error) {
+        console.error("Error fetching data: ", error);
+        window.scriptReady = true;
+      }
+    };
+  
+    // Start the service and fetch the data
+    startService();
+    fetchData();
+
+  }, 1000);
+
+
+}
 )();
-*/

--- a/smarthub.js
+++ b/smarthub.js
@@ -1,0 +1,140 @@
+/*(
+
+  function () {
+    'use strict';
+*/
+import { Service } from 'wrt:service';
+
+var pkg_id = tizen.application.getCurrentApplication().appInfo.packageId;
+var service_id = pkg_id + ".service";
+var localJsonData = undefined;
+
+
+function create_title_json(title_data) {
+
+  var action_data =
+  {
+    serverid: title_data.ServerId,
+    id: title_data.Id
+  };
+
+
+  var obj = {
+    title: "S"+title_data.ParentIndexNumber+":E"+title_data.IndexNumber+" - "+title_data.Name,
+    subtitle: "Subtitle",
+    image_ratio: "1by1",
+    image_url: "https://artworks.thetvdb.com/banners/fanart/original/78901-80.jpg",
+    //image_url: "http://192.168.31.62:8096/Items/5f6a38a4adfd66d4d3e838f0bb19e050/Images/Thumb?fillHeight=122&fillWidth=216&format=jpg&quality=96&tag=3e557bd01b366b69311d41a555d2bd96",
+    action_data: JSON.stringify(action_data), // Escaped JSON string
+    is_playable: true
+  };
+  return obj
+}
+
+function create_smart_view_json(data) {
+  var obj = {
+    sections: [
+      {
+        title: "Ajanlott",
+        tiles: [create_title_json(data[0])]
+      },
+      {
+        title: "Folytasd",
+        tiles: [
+          create_title_json(data[1]),
+          create_title_json(data[2]),
+          create_title_json(data[3]),
+          create_title_json(data[4]),
+        ]
+      }
+    ]
+  };
+  return obj
+}
+
+function send_message_to_service() {
+
+  try {
+    tizen.application.launchAppControl(
+      new tizen.ApplicationControl(
+        'http://tizen.org/appcontrol/operation/pick',
+        null,
+        'image/jpeg',
+        null,
+        [
+          new tizen.ApplicationControlData('caller', [JSON.stringify(localJsonData)]),
+          new tizen.ApplicationControlData('Preview', [JSON.stringify(localJsonData)])
+        ]
+      ),
+      service_id,
+      () => console.log('Message: ' + JSON.stringify(localJsonData) + ' sent to ' + service_id),
+      (error) => console.error('Launch failed:', error.message)
+    );
+  } catch (error) {
+    console.error("Error sending message:", error);
+
+  }
+}
+
+
+var OnReceived = function (ui_data) {
+  console.log("Received Data in Service : " + ui_data[0].value);
+};
+
+function delay(time) {
+  return new Promise(resolve => setTimeout(resolve, time));
+}
+
+
+var local_message_port = tizen.messageport.requestLocalMessagePort(pkg_id + ".DataChannel");
+var message_port_listener = local_message_port.addMessagePortListener(OnReceived);
+
+
+var interval = setInterval(function () {
+  // get elem
+  if (typeof ApiClient == 'undefined') return;
+  clearInterval(interval);
+  const address = ApiClient.getResumableItems(ApiClient.getCurrentUserId())
+    .then((response) => {
+      return response.Items;
+    });
+
+  const printAddress = async () => {
+    const a = await address;
+
+    console.log(JSON.stringify(create_smart_view_json(a)));
+    localJsonData = create_smart_view_json(a);
+
+    delay(2000).then(() => {
+      console.log('ran after 2 second1 passed');
+      send_message_to_service(localJsonData);
+    });
+
+    /*delay(6000).then(() => {
+      console.log('ran after 6 second1 passed');
+      send_message_to_service(localJsonData);
+    });*/
+  };
+
+
+  var my_service = new Service(service_id);
+  my_service.start().then(function () {
+    console.log("Succeeded to start service333");
+  },
+    function (error) {
+      console.log("Failed to start service: " + error);
+
+    });
+
+  printAddress();
+
+
+
+
+  // the rest of the code
+}, 1000);
+
+/*
+  }
+)();
+*/

--- a/tizen.js
+++ b/tizen.js
@@ -80,32 +80,6 @@
         console.log.apply(console, arguments);
     }
 
-    function loadScript(src) {
-        return new Promise((resolve, reject) => {
-            var script = document.createElement('script');
-            script.src = src;
-            script.type = 'text/javascript';
-            window.scriptReady = false;
-
-            script.onload = function () {
-                const checkReady = () => {
-                    if (window.scriptReady) {
-                        resolve();
-                    } else {
-                        setTimeout(checkReady, 100);
-                    }
-                };
-                checkReady();
-            };
-
-            script.onerror = function () {
-                reject(new Error(`SmartHubPreview not loaded ${src}`));
-            };
-
-            document.head.appendChild(script);
-        });
-    }
-
     window.NativeShell = {
         AppHost: {
             init: function () {
@@ -137,12 +111,11 @@
 
             exit: async function () {
                 try {
-                    //console.log('Refresh SmartHubPrewiev on exit...');
-                    //await loadScript('../smarthub.js');
-                    //postMessage('AppHost.exit');
+                    await runSmartViewUpdate();
                     tizen.application.getCurrentApplication().exit();
                 } catch (error) {
                     console.error('Error:', error.message);
+                    tizen.application.getCurrentApplication().exit();
                 }
             },
 

--- a/tizen.js
+++ b/tizen.js
@@ -3,6 +3,31 @@
 
     console.log('Tizen adapter');
 
+    // Function to get the Tizen version
+    function getTizenVersion() {
+        try {
+            const version = tizen.systeminfo.getCapability('http://tizen.org/feature/platform.version');
+            return parseFloat(version);
+        } catch (error) {
+            console.warn('Unable to determine Tizen version:', error);
+            return 0; // Default to 0 if version cannot be determined
+        }
+    }
+
+    // Check Tizen version and dynamically load smarthub.js if supported
+    const tizenVersion = getTizenVersion();
+    if (tizenVersion > 3) {
+        console.log('Loading smarthub.js for Tizen version:', tizenVersion);
+
+        // Dynamically load smarthub.js
+        const script = document.createElement('script');
+        script.src = '../smarthub.js';
+        script.defer = true;
+        document.head.appendChild(script);
+    } else {
+        console.log('Skipping smarthub.js for Tizen version:', tizenVersion);
+    }
+
     // Similar to jellyfin-web
     function generateDeviceId() {
         return btoa([navigator.userAgent, new Date().getTime()].join('|')).replace(/=/g, '1');

--- a/tizen.js
+++ b/tizen.js
@@ -235,13 +235,32 @@
 
                     // If the action data contains a server ID, assume it is a valid Jellifyn link
                     if (JSON.parse(actionData).serverid) {
-                        var serverid = JSON.parse(actionData).serverid
-                        var id = JSON.parse(actionData).id
+                        var serverid = JSON.parse(actionData).serverid;
+                        var id = JSON.parse(actionData).id;
+                        var type = JSON.parse(actionData).type;
+                        var seasonid = JSON.parse(actionData).seasonid;
+                        var seriesid = JSON.parse(actionData).seriesid;
 
+
+                        /* Based on  Deep-link Return Key Policy ( https://developer.samsung.com/smarttv/develop/guides/smart-hub-preview/smart-hub-preview.html#Deep-link-Return-Key-Policy)
+                           From a detail page within an application, clicking the “Return/Exit” key must display the previous page in the application.
+                           https://developer.samsung.com/media/2424/uxguidelines4.png
+                        */
+                        history.pushState({}, '', 'file:///www/home.html');
+                        if (type =='episode')
+                        {
+                            history.pushState({}, '', 'file:///www/index.html#/tv.html');
+                            history.pushState({}, '', "file:///www/index.html#/details?id=" + seriesid + "&serverId=" + serverid);
+                            history.pushState({}, '', "file:///www/index.html#/details?id=" + seasonid + "&serverId=" + serverid);
+
+                        }
+                        if (type =='movie')
+                        {
+                            history.pushState({}, '', 'file:///www/index.html#/movies.html');
+                        }
                         // Construct the URL for the details page and redirect
-                        var newUrl = "file:///www/index.html#/details?id=" + id + "&serverId=" + serverid;
-                        window.location.href = newUrl;
-                        console.log(newUrl);
+                        history.pushState({}, '', "file:///www/index.html#/details?id=" + id + "&serverId=" + serverid);
+
 
                     }
                 }

--- a/tizen.js
+++ b/tizen.js
@@ -233,13 +233,16 @@
                     actionData = JSON.parse(appControlData[i].value[0]).values;
                     console.log('Get element info ' + actionData);
 
+                    // Store the parsed action data in a variable
+                    const parsedActionData = JSON.parse(actionData);
+
                     // If the action data contains a server ID, assume it is a valid Jellifyn link
-                    if (JSON.parse(actionData).serverid) {
-                        var serverid = JSON.parse(actionData).serverid;
-                        var id = JSON.parse(actionData).id;
-                        var type = JSON.parse(actionData).type;
-                        var seasonid = JSON.parse(actionData).seasonid;
-                        var seriesid = JSON.parse(actionData).seriesid;
+                    if (parsedActionData.serverid) {
+                        var serverid = parsedActionData.serverid;
+                        var id = parsedActionData.id;
+                        var type = parsedActionData.type;
+                        var seasonid = parsedActionData.seasonid;
+                        var seriesid = parsedActionData.seriesid;
 
 
                         /* Based on  Deep-link Return Key Policy ( https://developer.samsung.com/smarttv/develop/guides/smart-hub-preview/smart-hub-preview.html#Deep-link-Return-Key-Policy)

--- a/tizen.js
+++ b/tizen.js
@@ -199,4 +199,47 @@
     }
 
     window.addEventListener('viewshow', updateKeys);
+
+    //Deeplink
+    var text = '';
+
+    function deepLink() {
+        var requestedAppControl = tizen.application.getCurrentApplication().getRequestedAppControl();
+        var appControlData;
+        var actionData;
+
+        if (requestedAppControl) {
+            appControlData = requestedAppControl.appControl.data; // get appcontrol data. action_data is in it.
+            text = '[TestApp] appControlData : ' + JSON.stringify(appControlData);
+            console.log(text);
+
+            for (var i = 0; i < appControlData.length; i++) {
+                console.log(appControlData[i].key);
+                if (appControlData[i].key == 'PAYLOAD') { // find PAYLOAD property.
+                    console.log('Payload');
+                    actionData = JSON.parse(appControlData[i].value[0]).values; // Get action_data
+                    console.log('aaaa ' + actionData);
+                    if (JSON.parse(actionData).serverid) { // in case Tile is video.
+                        var serverid = JSON.parse(actionData).serverid
+                        var id = JSON.parse(actionData).id
+
+                        text = '[TestApp] videoIdx : ' + serverid;
+                        var newUrl = "file:///www/index.html#/details?id=" + id + "&serverId=" + serverid;
+                        window.location.href = newUrl;
+                        console.log(newUrl);
+
+                    }
+                }
+            }
+        } else {
+            console.log('no req app control');
+        }
+    }
+
+
+    // add appcontrol event with deepLink function
+    window.addEventListener('appcontrol', deepLink);
+    // call deepLink function for first load
+    deepLink();
+
 })();

--- a/tizen.js
+++ b/tizen.js
@@ -137,9 +137,9 @@
 
             exit: async function () {
                 try {
-                    console.log('Refresh SmartHubPrewiev on exit...');
-                    await loadScript('../smarthub.js');
-                    postMessage('AppHost.exit');
+                    //console.log('Refresh SmartHubPrewiev on exit...');
+                    //await loadScript('../smarthub.js');
+                    //postMessage('AppHost.exit');
                     tizen.application.getCurrentApplication().exit();
                 } catch (error) {
                     console.error('Error:', error.message);


### PR DESCRIPTION
This pull request introduces support for Samsung Smart Hub Preview integration, enabling Jellifyn users to leverage the native Smart Hub capabilities for better app discoverability and user experience.

**Key Features:**

**- Smart Hub Preview Support:**

- Added integration with Samsung's Smart Hub Preview API.
- Supports displaying rich content previews and deep linking directly from the Smart Hub interface.

**-Default Configuration:**

- **Next Up:** Displays 2 items.
- **Continue Watching:** Displays 4 items.

**Testing:**

- Fully tested and verified on Tizen 4 (emulator and TV).
- Tested on Tizen 5 emulator.

**Resolves:**
This implementation addresses and resolves [issue #318](https://github.com/jellyfin/jellyfin-tizen/issues/318).

**Work in Progress:**

- I am looking for additional testers, especially on newer tizen versions

- Decisions are still pending on:

  - Optimal number of elements for different sections.
  - Additional sections that could be useful for various content types.

**Next Steps:**

- Feedback on current implementation and configurations.

- Suggestions for additional sections or adjustments to the item limits.

- More testing on a wider range of devices and scenarios.

**Reference:**
For more details on Smart Hub Preview capabilities, refer to the [Samsung Developer Guide](https://developer.samsung.com/smarttv/develop/guides/smart-hub-preview/smart-hub-preview.html).

Thank you for reviewing this PR! I look forward to feedback and suggestions to enhance this feature further.

![emulator-x86_64_UrptYPG3wg](https://github.com/user-attachments/assets/6de5c225-11b1-4b30-95b1-bf6595564ac1)
