### PR TITLE
Readme correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If any changes are made to `jellyfin-web/dist/`, the `jellyfin-tizen/www/` direc
 > Make sure you select the appropriate Certificate Profile in Tizen Certificate Manager. This determines which devices you can install the widget on.
 
 ```sh
-tizen build-web -e ".*" -e gulpfile.js -e README.md -e "node_modules/*" -e "package*.json" -e "yarn.lock"
+tizen build-web -e ".*" -e gulpfile.babel.js -e README.md -e "node_modules/*" -e "package*.json" -e "yarn.lock"
 tizen package -t wgt -o . -- .buildResult
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,11 @@ _Also look [Wiki](https://github.com/jellyfin/jellyfin-tizen/wiki)._
 
 ```sh
 cd jellyfin-web
-SKIP_PREPARE=1 npm ci --no-audit
+npm ci --no-audit
 USE_SYSTEM_FONTS=1 npm run build:production
 ```
 
 > You should get `jellyfin-web/dist/` directory.
-
-> `SKIP_PREPARE=1` can be omitted for 10.9+.
 
 > `USE_SYSTEM_FONTS=1` is required to discard unused fonts and to reduce the size of the app. (Since Jellyfin Web 10.9)
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ _Also look [Wiki](https://github.com/jellyfin/jellyfin-tizen/wiki)._
    > It is recommended that the web version match the server version.
 
    ```sh
-   git clone -b release-10.9.z https://github.com/jellyfin/jellyfin-web.git
+   git clone -b release-10.10.z https://github.com/jellyfin/jellyfin-web.git
    ```
-   > Replace `release-10.9.z` with the name of the branch you want to build.
+   > Replace `release-10.10.z` with the name of the branch you want to build.
 
    > You can also use `git checkout` to switch branches.
 5. Clone or download Jellyfin Tizen (this) repository.


### PR DESCRIPTION
### Fixes

- **README Bug**: Corrected the file exclusion for building the web app. gulpfile.js was incorrectly excluded instead of gulpfile.babel.js. ([Fix Commit](https://github.com/jellyfin/jellyfin-tizen/commit/575ac0d5caac3de739a0ff60729da5f52dff2199))

### Improvements

- **Added Latest Version:** Updated the README to include the latest release version (release-10.10.z). ([Improvement Commit](https://github.com/jellyfin/jellyfin-tizen/commit/ee1e6b251340d41e3a55a971653f22143d3fd7cd))

- **Split Build Instructions:** Separated build instructions for Jellyfin Web 10.8- and 10.9+ for clarity and ease of use. ([Improvement Commit](https://github.com/jellyfin/jellyfin-tizen/commit/52cd38e863d4378103323d3116a8b4d82021c51c))