### PR TITLE
Disable IME when non-user action

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -7,6 +7,7 @@
     <description>Jellyfin for Samsung Smart TV (Tizen).</description>
     <feature name="http://tizen.org/feature/screen.size.all"/>
     <icon src="icon.png"/>
+    <tizen:metadata key="http://samsung.com/tv/metadata/use.keypad.without.useraction" value="false"/>
     <tizen:metadata key="http://tizen.org/metadata/app_ui_type/base_screen_resolution" value="fullscreen"/>
     <name>Jellyfin</name>
     <tizen:privilege name="http://developer.samsung.com/privilege/productinfo"/>


### PR DESCRIPTION
[See also](https://developer.samsung.com/smarttv/develop/guides/user-interaction/keyboardime.html#IME-Enable%2FDisable)
> Disable IME only when non-user action method:
Indicate only when user action can show IME, such as press "Enter" key on editable element by Remote Control, or click on the editable element by mouse. When JS set focus on editable element automatically, IME can not be shown.

**Issues**
Fixes #356 