### PR TITLE
Create build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Build WGT
 
 on:
-  push:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,23 @@ jobs:
         run: |
           cd jellyfin-tizen
           ../tizen-studio/tools/ide/bin/tizen package -t wgt -o ./release -- .buildResult
+          
+      - name: Print job summary
+        run: |
+          cat >> $GITHUB_STEP_SUMMARY << 'EOF'
+          ## Package Signing Required
+
+          The `Jellyfin.wgt` package is **not signed**.
+
+          ### To sign the package:
+    
+          1. Download the `Jellyfin.wgt` artifact from this workflow run
+          2. Run the following command:
+          
+          ```bash
+          tizen package -t wgt -s MyProfile -- Jellyfin.wgt
+          ```
+          EOF
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: 'v23.11.1'
           cache: 'npm'
           cache-dependency-path: |
             jellyfin-web/package-lock.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  TIZEN_STUDIO_VER: 6.1
+  TIZEN_STUDIO_VER: 4.5.1
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,79 @@
+name: Build WGT
+
+on:
+  push:
+  workflow_dispatch:
+
+env:
+  TIZEN_STUDIO_URL: https://download.tizen.org/sdk/Installer/tizen-studio_$TIZEN_STUDIO_VER/web-cli_Tizen_Studio_$TIZEN_STUDIO_VER_ubuntu-64.bin
+
+jobs:
+  build:
+    name: Build Artifact
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Tizen-Studio
+        run: |
+          curl -o tizen-installer "https://download.tizen.org/sdk/Installer/tizen-studio_${TIZEN_STUDIO_VER}/web-cli_Tizen_Studio_${TIZEN_STUDIO_VER}_ubuntu-64.bin"
+
+      - name: Install Tizen-Studio
+        run: |
+          chmod +x tizen-installer
+          ./tizen-installer --accept-license "${GITHUB_WORKSPACE}/tizen-studio"
+          rm ./tizen-installer
+          echo 'export PATH=$PATH:/tizen-studio/tools/ide/bin' >> .bashrc
+
+      - name: Clone jellyfin-tizen
+        uses: actions/checkout@v6
+        with:
+          repository: 'jellyfin/jellyfin-tizen'
+          path: 'jellyfin-tizen'
+          ref: 'master'
+
+      - name: Get latest jellyfin-web release
+        id: latestrelease
+        run: |
+          echo "::set-output name=releasetag::$(curl -s https://api.github.com/repos/jellyfin/jellyfin-web/releases/latest | jq '.tag_name' | sed 's/\"//g')"
+
+      - name: confirm release tag
+        run: |
+          echo ${{ steps.latestrelease.outputs.releasetag }}
+
+      - name: Clone jellyfin-web
+        uses: actions/checkout@v6
+        with:
+          repository: 'jellyfin/jellyfin-web'
+          path: 'jellyfin-web'
+          ref: ${{ steps.latestrelease.outputs.releasetag }}
+
+      - name: Build jellyfin-web
+        run: |
+          cd jellyfin-web
+          npm ci --no-audit
+          USE_SYSTEM_FONTS=1 npm run build:production
+
+      - name: Build jellyfin-tizen
+        run: |
+          cd jellyfin-tizen
+          JELLYFIN_WEB_DIR=../jellyfin-web/dist npm ci --no-audit
+
+      - name: Build package
+        run: |
+          cd jellyfin-tizen
+          ../tizen-studio/tools/ide/bin/tizen build-web -e ".*" -e gulpfile.js -e README.md -e "node_modules/*" -e "package*.json" -e "yarn.lock"
+
+      - name: Package WGT
+        run: |
+          cd jellyfin-tizen
+          ../tizen-studio/tools/ide/bin/tizen package -t wgt -o ./release -s Jellyfin -- .buildResult
+
+      - name: Print logs
+        if: always()
+        run: cat ./tizen-studio-data/cli/logs/cli.log
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: Jellyfin
+          path: jellyfin-tizen/release/Jellyfin.wgt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build WGT
 
 on:
+  push:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,16 +13,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Cache Tizen Studio
+        id: cache-tizen
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/tizen-studio
+          key: tizen-studio-${{ env.TIZEN_STUDIO_VER }}
+
       - name: Download Tizen-Studio
+        if: steps.cache-tizen.outputs.cache-hit != 'true'
         run: |
           curl -o tizen-installer "https://download.tizen.org/sdk/Installer/tizen-studio_${TIZEN_STUDIO_VER}/web-cli_Tizen_Studio_${TIZEN_STUDIO_VER}_ubuntu-64.bin"
 
       - name: Install Tizen-Studio
+        if: steps.cache-tizen.outputs.cache-hit != 'true'
         run: |
           chmod +x tizen-installer
           ./tizen-installer --accept-license "${GITHUB_WORKSPACE}/tizen-studio"
-          rm ./tizen-installer
-          echo 'export PATH=$PATH:/tizen-studio/tools/ide/bin' >> .bashrc
+          rm ./tizen-installer  
+
+      - name: Add Tizen Studio to PATH
+        run: |
+          echo "${GITHUB_WORKSPACE}/tizen-studio/tools/ide/bin" >> $GITHUB_PATH
 
       - name: Clone jellyfin-tizen
         uses: actions/checkout@v6
@@ -43,7 +55,24 @@ jobs:
           path: 'jellyfin-web'
           ref: ${{ steps.latestrelease.outputs.releasetag }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: |
+            jellyfin-web/package-lock.json
+            jellyfin-tizen/package-lock.json
+
+      - name: Cache jellyfin-web dist
+        id: cache-web-dist
+        uses: actions/cache@v5
+        with:
+          path: jellyfin-web/dist
+          key: jellyfin-web-dist-${{ steps.latestrelease.outputs.releasetag }}-${{ hashFiles('jellyfin-web/package-lock.json') }}
+
       - name: Build jellyfin-web
+        if: steps.cache-web-dist.outputs.cache-hit != 'true'
         run: |
           cd jellyfin-web
           npm ci --no-audit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Get latest jellyfin-web release
         id: latestrelease
         run: |
-          echo "::set-output name=releasetag::$(curl -s https://api.github.com/repos/jellyfin/jellyfin-web/releases/latest | jq '.tag_name' | sed 's/\"//g')"
+          echo "releasetag=$(curl -s https://api.github.com/repos/jellyfin/jellyfin-web/releases/latest | jq '.tag_name' | sed 's/\"//g')" >> "$GITHUB_OUTPUT"
 
       - name: confirm release tag
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,10 +36,6 @@ jobs:
         run: |
           echo "releasetag=$(curl -s https://api.github.com/repos/jellyfin/jellyfin-web/releases/latest | jq '.tag_name' | sed 's/\"//g')" >> "$GITHUB_OUTPUT"
 
-      - name: confirm release tag
-        run: |
-          echo ${{ steps.latestrelease.outputs.releasetag }}
-
       - name: Clone jellyfin-web
         uses: actions/checkout@v6
         with:
@@ -67,10 +63,6 @@ jobs:
         run: |
           cd jellyfin-tizen
           ../tizen-studio/tools/ide/bin/tizen package -t wgt -o ./release -- .buildResult
-
-      - name: Print logs
-        if: always()
-        run: cat ./tizen-studio-data/cli/logs/cli.log
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Package WGT
         run: |
           cd jellyfin-tizen
-          ../tizen-studio/tools/ide/bin/tizen package -t wgt -o ./release -s Jellyfin -- .buildResult
+          ../tizen-studio/tools/ide/bin/tizen package -t wgt -o ./release -- .buildResult
 
       - name: Print logs
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  TIZEN_STUDIO_URL: https://download.tizen.org/sdk/Installer/tizen-studio_$TIZEN_STUDIO_VER/web-cli_Tizen_Studio_$TIZEN_STUDIO_VER_ubuntu-64.bin
+  TIZEN_STUDIO_VER: 6.1
 
 jobs:
   build:


### PR DESCRIPTION
As I promised @anthonylavado in #222, I now have a build pipeline. The pipeline has been tested and the result can be seen [here](https://github.com/jeppevinkel/jellyfin-tizen/actions/runs/21841242920)

This PR aims to create a basic build pipeline that allows efficiently building a WGT package for the client in a controlled manner.

This pipeline is a trimmed down and slightly optimized version of what I've been doing in my repository [here](https://github.com/jeppevinkel/jellyfin-tizen-builds/blob/master/.github/workflows/build-new-release.yml)

The pipeline fetches the latest release tag from jellyfin-web, and the master branch from jellyfin-tizen. It then builds an unsigned package, and uploads it as an artifact.

I have added caching for the Tizen CLI, node modules, and the build of jellyfin-web in an attempt to speed up subsequent builds when debugging. This should not affect the builds in case of updates as the caches are keyed on the package-lock files.

Since these builds are unsigned, they will need to be signed afterwards with the tizen cli in a manner like `tizen package -t wgt -s MyProfile -- Jellyfin.wgt`. This is also documented in the pipeline itself. The reason for the builds being unsigned is because I don't have experience with actual publisher certificates. If possible and safe enough, a certificate could potentially be added as a repository secret to allow the pipeline to make signed builds.

The pipeline uses a `workflow_dispatch` to run automatically since I don't know of a mechanism currently in place in the repository to signify releases.