### PR TITLE
Added dockerfile, scripts, and instrutions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,117 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Jellyfin Tizen — Samsung cert creator + WGT builder (everything in Docker)
+#
+# Build (one time):
+#   docker build -t jellyfin-tizen .
+#
+# Create Samsung certs (one time, opens browser UI on port 6080):
+#   docker run -it --rm \
+#     -e TV_DUID="YOUR_TV_DUID" \
+#     -p 6080:6080 \
+#     -v "$(pwd)/certs:/certs" \
+#     jellyfin-tizen /create-certs.sh
+#   → Open http://localhost:6080/vnc.html in your browser
+#
+# Build Jellyfin.wgt:
+#   docker run --rm \
+#     -v "$(pwd)/certs/author.p12:/certs/author.p12:ro" \
+#     -v "$(pwd)/certs/distributor.p12:/certs/distributor.p12:ro" \
+#     -v "$(pwd)/output:/output" \
+#     jellyfin-tizen /build-wgt.sh
+# ─────────────────────────────────────────────────────────────────────────────
+# Tizen Studio only ships x86-64 binaries — force amd64 even on Apple Silicon
+FROM --platform=linux/amd64 ubuntu:22.04
+
+LABEL description="Jellyfin Tizen — Samsung cert creator + WGT builder"
+
+ARG TIZEN_VERSION=6.0
+ARG CERT_EXT_URL=https://download.tizen.org/sdk/extensions/tizen-certificate-extension_2.0.73.zip
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TIZEN_VERSION=${TIZEN_VERSION} \
+    CERT_EXT_URL=${CERT_EXT_URL} \
+    JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+
+# ── 1. System packages ────────────────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        openjdk-17-jre-headless \
+        git wget curl \
+        # Virtual display + window manager
+        xvfb fluxbox \
+        # VNC + noVNC for browser-based GUI access
+        x11vnc novnc python3-websockify \
+        # GTK2 required by SWT/Eclipse (libgtk-x11-2.0.so.0)
+        libgtk2.0-0 \
+        # Other Eclipse runtime dependencies
+        libglib2.0-0 libgl1 libnss3 libx11-xcb1 libdbus-glib-1-2 libxt6 \
+        # KDE/Qt5 libs required by Certificate Manager (cert-add-on)
+        libkf5itemmodels5 libkf5kiowidgets5 libkchart2 \
+        # Required by Tizen Studio package-manager for .rpm packages
+        rpm2cpio cpio \
+        # openssl used to strip .p12 passwords before registering cert profile
+        openssl \
+        # xdg-utils provides xdg-open, needed by Certificate Manager Samsung OAuth
+        xdg-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── 1b. Google Chrome — Certificate Manager opens Samsung OAuth in a browser ──
+# Chrome's .deb works natively in linux/amd64 Docker (no snap required).
+RUN wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+         -O /tmp/chrome.deb \
+    && apt-get update && apt-get install -y --no-install-recommends /tmp/chrome.deb \
+    && rm /tmp/chrome.deb \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── 2. Node.js 20 ─────────────────────────────────────────────────────────────
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── 3. Non-root user — Tizen Studio installer refuses root ───────────────────
+# X11 socket dir must pre-exist with sticky bit so non-root Xvfb can write to it.
+RUN useradd -m -u 1000 -s /bin/bash builder \
+    && mkdir -p /tmp/.X11-unix \
+    && chmod 1777 /tmp/.X11-unix
+
+ENV TIZEN_SDK=/home/builder/tizen-studio \
+    TIZEN_DATA=/home/builder/tizen-studio-data \
+    PATH=/home/builder/tizen-studio/tools/ide/bin:/home/builder/tizen-studio/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# ── 4. Install Tizen Studio web-cli (headless, no GUI needed) ─────────────────
+#    web-cli gives us all CLI build+signing tools. The web-IDE (Certificate
+#    Manager GUI) is downloaded and installed at runtime by create-certs.sh
+#    to keep docker build fast and reliable.
+RUN wget -nv \
+        "https://download.tizen.org/sdk/Installer/tizen-studio_${TIZEN_VERSION}/web-cli_Tizen_Studio_${TIZEN_VERSION}_ubuntu-64.bin" \
+        -O /tmp/tizen.bin \
+    && chmod +x /tmp/tizen.bin
+
+USER builder
+RUN /tmp/tizen.bin --accept-license "$TIZEN_SDK" \
+    && test -d "$TIZEN_SDK" || (echo "ERROR: Tizen Studio did not install" && exit 1)
+
+# ── 5. Copy scripts (root) ────────────────────────────────────────────────────
+USER root
+RUN rm -f /tmp/tizen.bin
+COPY --chown=builder:builder create-certs.sh /create-certs.sh
+COPY --chown=builder:builder build-wgt.sh /build-wgt.sh
+COPY --chown=builder:builder install-wgt.sh /install-wgt.sh
+# Replace Tizen's bundled secret-tool (requires dbus-launch / GNOME Keyring,
+# which is unavailable headless) with a simple file-based implementation.
+# LinuxCrypt.java calls this to store/retrieve .p12 passwords by keyfile path.
+COPY --chown=builder:builder secret-tool.sh \
+    /home/builder/tizen-studio/tools/certificate-encryptor/secret-tool
+RUN chmod +x /create-certs.sh /build-wgt.sh /install-wgt.sh \
+             /home/builder/tizen-studio/tools/certificate-encryptor/secret-tool
+
+USER builder
+WORKDIR /home/builder/build
+
+# Pre-create output dirs so named/bind volumes inherit correct ownership
+RUN mkdir -p /home/builder/build
+USER root
+RUN mkdir -p /certs /output && chown builder:builder /certs /output
+USER builder
+
+CMD ["/bin/bash"]
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,173 @@
+# Jellyfin Tizen WGT Builder
+
+Builds `Jellyfin.wgt` for Samsung Tizen TVs. **Everything runs inside Docker** — no tools need to be installed on your host machine.
+
+## Prerequisites
+
+- Docker
+- Samsung account (free — [register here](https://developer.samsung.com))
+- A browser (for the certificate creation step)
+
+---
+
+## Build the Docker image (one time)
+
+```bash
+docker build -t jellyfin-tizen .
+```
+
+Installs Tizen Studio web-CLI (headless build tools), system display libraries (for Certificate Manager GUI), and Node.js 20 into a `linux/amd64` Ubuntu image. Expect ~5–10 min and ~2 GB.
+
+> **Different Tizen Studio version:**
+> ```bash
+> docker build --build-arg TIZEN_VERSION=5.6 -t jellyfin-tizen .
+> ```
+> Available versions: https://download.tizen.org/sdk/Installer/
+
+---
+
+## Step 1 — Create Samsung certificates (one time)
+
+Samsung TVs only install apps signed with a certificate tied to your **TV's DUID** and your **Samsung Developer account**. This needs to be done once.
+
+### 1a. Get your TV's Device Unique ID (DUID)
+
+On the TV: **Apps → press `12345` on the remote** → note the Unique Device ID shown.  
+(Also found at: Settings → Support → Contact Samsung → Unique Device ID)
+
+### 1b. Run the certificate creator
+
+```bash
+mkdir -p certs cache data
+
+docker run -it --rm \
+  -e TV_DUID="YOUR_TV_DUID" \
+  -p 6080:6080 \
+  -v ./certs:/certs \
+  -v ./cache:/cache \
+  -v ./data:/home/builder/tizen-studio-data \
+  jellyfin-tizen /create-certs.sh
+```
+
+For multiple TVs, comma-separate the DUIDs:
+
+```bash
+  -e TV_DUID="DUID1,DUID2,DUID3"
+```
+
+**Volume guide (host bind-mounts):**
+
+| Host path | What it holds |
+|---|---|
+| `./certs` | Output: `author.p12`, `distributor.p12`, `duids.txt`, `SamsungCertificate/` (full backup), `keystore/` |
+| `./cache` | 663 MB installer binary — skips re-download on subsequent runs |
+| `./data` | Keystore and profiles — preserves certs across runs |
+
+No `./sdk` volume needed. The IDE installs fresh each run (fast after the first download since `./cache` has the binary).
+
+## Open **http://localhost:6080/vnc.html** then follow the installer:
+
+1. Accept license → Next
+2. **Keep the default path** `/home/builder/tizen-studio` → Install
+   > If prompted for a separate SDK data path, choose any empty directory (e.g. `/sdk`).
+3. Wait for progress bar → **uncheck "Launch Package Manager"** → Finish
+4. Wait for component installation in the docker output
+5. when components are installed, the cert manager will launch in noVNC (browser)
+6. Certificate Manager opens automatically
+
+In Certificate Manager:
+
+1. Click **+** → **Samsung** → **TV** → Next
+2. Enter a profile name → Next
+3. Create a new author certificate — sign in with your Samsung Developer account
+4. Create distributor certificate — enter each DUID shown in your terminal → Finish
+
+The script automatically copies `certs/author.p12`, `certs/distributor.p12`, and a full `certs/SamsungCertificate/` backup to your host, then exits.
+
+> **Distributor cert is TV-specific.** If you get a new TV, re-run with the new DUID added to the list.
+
+---
+
+## Step 2 — Build Jellyfin.wgt
+
+```bash
+mkdir -p build output
+
+read -rsp "Certificate password (default: tizen): " CERT_PASS && echo && export CERT_PASS
+
+docker run --rm \
+  -e CERT_PASS \
+  -v "$(pwd)/certs/my-tv/author.p12:/certs/author.p12:ro" \
+  -v "$(pwd)/certs/my-tv/distributor.p12:/certs/distributor.p12:ro" \
+  -v "$(pwd)/build:/build" \
+  -v "$(pwd)/output:/output" \
+  jellyfin-tizen /build-wgt.sh
+```
+
+`-e CERT_PASS` without `=value` inherits from your shell — never stored in history.
+
+**Volume guide:**
+
+| Host path | What it holds |
+|---|---|
+| `./certs/.../*.p12` | Your Samsung author + distributor certs (read-only) |
+| `./build` | Git repos + `node_modules` cache — skips re-clone/re-install on subsequent runs |
+| `./output` | Output: `Jellyfin.wgt` |
+
+### Build a specific version
+
+| Variable | Default | Description |
+|---|---|---|
+| `JELLYFIN_VERSION` | `10.11.6` | Jellyfin version — auto-derives `WEB_BRANCH` (e.g. `10.11.6` → `release-10.11.z`) |
+| `WEB_BRANCH` | _(derived)_ | Override `jellyfin-web` branch/tag explicitly |
+| `TIZEN_BRANCH` | `master` | `jellyfin-tizen` branch/tag |
+
+```bash
+docker run --rm \
+  -e CERT_PASS \
+  -e JELLYFIN_VERSION="10.11.6" \
+  -v "$(pwd)/certs/my-tv/author.p12:/certs/author.p12:ro" \
+  -v "$(pwd)/certs/my-tv/distributor.p12:/certs/distributor.p12:ro" \
+  -v "$(pwd)/build:/build" \
+  -v "$(pwd)/output:/output" \
+  jellyfin-tizen /build-wgt.sh
+```
+
+---
+
+## Step 3 — Install on your TV
+
+### Enable Developer Mode on the TV (one time per reboot)
+
+1. Go to **Apps** → press **12345** on the remote
+2. Enable Developer Mode → enter your **host machine's LAN IP** → reboot TV
+
+> Developer mode is disabled on every TV power cycle — re-enable it before each install session.
+
+### Run the installer
+
+```bash
+docker run --rm --network host \
+  -e TV_IP="192.168.1.100" \
+  -v "$(pwd)/output:/output" \
+  jellyfin-tizen /install-wgt.sh
+```
+
+**`--network host` requires a Linux host.** Docker Desktop on macOS runs containers inside a LinuxKit VM — even with `--network host`, the container cannot reach LAN devices (the VM is not on your LAN, only the Mac is). On macOS, install natively using [Tizen Studio CLI](https://developer.tizen.org/development/tizen-studio/download):
+
+```bash
+# macOS native (Tizen Studio CLI installed locally)
+sdb connect 192.168.1.100
+tizen install -n output/Jellyfin.wgt -s 192.168.1.100:26101
+```
+
+**Optional env vars:**
+
+| Variable | Default | Description |
+|---|---|---|
+| `TV_IP` | _(required)_ | TV IP address |
+| `TV_PORT` | `26101` | SDB port |
+| `WGT_FILE` | `/output/Jellyfin.wgt` | Path to `.wgt` inside the container |
+
+
+

--- a/docker/build-wgt.sh
+++ b/docker/build-wgt.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+# ─────────────────────────────────────────────────────────────────────────────
+# build-wgt.sh — Build Jellyfin.wgt
+#
+# Usage:
+#   docker run --rm \
+#     -v "$(pwd)/certs/author.p12:/certs/author.p12:ro" \
+#     -v "$(pwd)/certs/distributor.p12:/certs/distributor.p12:ro" \
+#     -v "$(pwd)/build:/build" \
+#     -v "$(pwd)/output:/output" \
+#     jellyfin-tizen /build-wgt.sh
+#
+# build/ layout (persisted across runs):
+#   build/repos/   ← git repos + node_modules (auto-managed, speeds up rebuilds)
+#
+# Optional env vars:
+#   JELLYFIN_VERSION — e.g. 10.11.6  (default: 10.11.6)
+#   WEB_BRANCH       — override jellyfin-web branch/tag explicitly
+#   TIZEN_BRANCH     — jellyfin-tizen branch/tag (default: master)
+#   CERT_PASS        — .p12 password (default: tizen)
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+BUILD_ROOT="${BUILD_ROOT:-/build}"
+REPOS_DIR="$BUILD_ROOT/repos"
+
+JELLYFIN_VERSION="${JELLYFIN_VERSION:-10.11.6}"
+_VER_MM=$(echo "$JELLYFIN_VERSION" | cut -d. -f1,2)
+WEB_BRANCH="${WEB_BRANCH:-release-${_VER_MM}.z}"
+TIZEN_BRANCH="${TIZEN_BRANCH:-master}"
+OUTPUT_DIR="${OUTPUT_DIR:-/output}"
+
+# Cert paths
+AUTHOR_CERT="${AUTHOR_CERT:-/certs/author.p12}"
+DIST_CERT="${DIST_CERT:-/certs/distributor.p12}"
+CERT_PASS="${CERT_PASS:-tizen}"
+DIST_CERT_PASS="${DIST_CERT_PASS:-$CERT_PASS}"
+
+# Validate CERT_PASS — must be non-empty and contain no whitespace/newlines
+[ -z "$CERT_PASS" ] && die "CERT_PASS is empty. Pass it with: read -rsp 'Password: ' CERT_PASS && export CERT_PASS"
+case "$CERT_PASS" in
+    *' '*|*$'\t'*|*$'\n'*|*$'\r'*)
+        die "CERT_PASS contains whitespace or newlines — check how you set it (use read -rsp, not echo)" ;;
+esac
+
+export NODE_OPTIONS="--max-old-space-size=4096"
+
+log() { echo ""; echo "==> $*"; }
+die() { echo ""; echo "ERROR: $*" >&2; exit 1; }
+
+# ── Ensure repos cache dir exists ────────────────────────────────────────
+mkdir -p "$REPOS_DIR"
+
+clone_or_update() {
+    local repo="$1" branch="$2" dir="$3"
+    if [ -d "$dir/.git" ]; then
+        local current
+        current=$(git -C "$dir" rev-parse HEAD 2>/dev/null || true)
+        log "Updating $dir to $branch …"
+        git -C "$dir" fetch --depth 1 origin "$branch"
+        git -C "$dir" checkout FETCH_HEAD
+        local updated
+        updated=$(git -C "$dir" rev-parse HEAD 2>/dev/null || true)
+        if [ "$current" = "$updated" ]; then
+            echo "    (no changes — using cached build)"
+        fi
+    else
+        log "Cloning $repo (branch: $branch) …"
+        git clone --depth 1 -b "$branch" "$repo" "$dir"
+    fi
+}
+
+npm_install() {
+    local extra_env="${1:-}"
+    if [ -d node_modules ] && [ -f package-lock.json ] && [ package-lock.json -ot node_modules ]; then
+        echo "==> node_modules up to date — skipping install"
+    else
+        log "Installing npm dependencies…"
+        env $extra_env npm ci --no-audit --prefer-offline 2>/dev/null \
+            || env $extra_env npm ci --no-audit
+    fi
+}
+
+echo ""
+echo "════════════════════════════════════════════════════════════"
+echo "  Jellyfin Tizen — Step 2: Build WGT"
+echo "════════════════════════════════════════════════════════════"
+echo "  jellyfin version : $JELLYFIN_VERSION"
+echo "  jellyfin-web     : $WEB_BRANCH"
+echo "  jellyfin-tizen   : $TIZEN_BRANCH"
+echo "  build cache      : $BUILD_ROOT"
+echo "  Output           : $OUTPUT_DIR/Jellyfin.wgt"
+echo "════════════════════════════════════════════════════════════"
+
+# ── Certificate profile ────────────────────────────────────────────────────
+[ -f "$AUTHOR_CERT" ] || die "Author cert not found at $AUTHOR_CERT"
+[ -f "$DIST_CERT"   ] || die "Distributor cert not found at $DIST_CERT"
+
+# Tizen's signing library (LinuxCrypt.java) stores passwords via the bundled
+# secret-tool binary using the .p12 file path as keyfile key. The certs must
+# be in a writable directory so Tizen can write the profiles.xml path entry;
+# passwords are then stored explicitly via secret-tool store (see below).
+CERT_DIR=$(mktemp -d /tmp/certs_XXXXXX)
+trap 'rm -rf "$CERT_DIR"' EXIT
+
+AUTHOR_TMP="$CERT_DIR/author.p12"
+DIST_TMP="$CERT_DIR/distributor.p12"
+cp "$AUTHOR_CERT" "$AUTHOR_TMP"
+cp "$DIST_CERT"   "$DIST_TMP"
+echo "==> Certs copied to writable dir: $CERT_DIR"
+
+CERT_PROFILE="SamsungProfile"
+log "Registering certificate profile…"
+ADD_OUTPUT=$(tizen security-profiles add \
+    -n "$CERT_PROFILE" \
+    -a "$AUTHOR_TMP" -p "$CERT_PASS" \
+    -d "$DIST_TMP"   -dp "${DIST_CERT_PASS:-$CERT_PASS}" 2>&1) || true
+echo "$ADD_OUTPUT"
+echo "$ADD_OUTPUT" | grep -qi "succeed\|Loaded in" \
+    || die "tizen security-profiles add failed — see output above"
+
+_xml_hint=$(echo "$ADD_OUTPUT" | grep -oP '(?<=profiles\.path=)[^\s"]+' | head -1)
+PROFILES_XML="${_xml_hint:-${TIZEN_SDK_DATA:-/home/builder/tizen-studio-data}/profile/profiles.xml}"
+
+echo "==> profiles.xml as written by Tizen:"
+cat "$PROFILES_XML"
+
+# LinuxCrypt.java (the signing library) stores/retrieves .p12 passwords via the
+# bundled secret-tool binary. Its encrypt() method runs in a background Thread
+# that races with JVM exit — so 'security-profiles add' may return before the
+# password is actually persisted. We call secret-tool store directly here after
+# parsing the keyfile paths from profiles.xml, guaranteeing the passwords are
+# available when 'tizen package' later calls secret-tool lookup.
+ST="${TIZEN_SDK:-/home/builder/tizen-studio}/tools/certificate-encryptor/secret-tool"
+
+AUTHOR_PWD=$(grep 'distributor="0"' "$PROFILES_XML" | grep -oP 'password="\K[^"]+')
+DIST_PWD=$(grep   'distributor="1"' "$PROFILES_XML" | grep -oP 'password="\K[^"]+')
+[ -n "$AUTHOR_PWD" ] || die "Could not find author password path in profiles.xml"
+[ -n "$DIST_PWD"   ] || die "Could not find distributor password path in profiles.xml"
+
+"$ST" store --label="tizen-studio" --password "$CERT_PASS"                    keyfile "$AUTHOR_PWD" tool certificate-manager
+"$ST" store --label="tizen-studio" --password "${DIST_CERT_PASS:-$CERT_PASS}" keyfile "$DIST_PWD"   tool certificate-manager
+echo "==> Passwords stored: $AUTHOR_PWD  $DIST_PWD"
+
+tizen cli-config "profiles.path=$PROFILES_XML"
+echo "==> CLI profiles path set to: $PROFILES_XML"
+
+# ── Clone / update source repos ───────────────────────────────────────────
+cd "$REPOS_DIR"
+
+clone_or_update \
+    "https://github.com/jellyfin/jellyfin-web.git" \
+    "$WEB_BRANCH" \
+    "jellyfin-web"
+
+clone_or_update \
+    "https://github.com/jellyfin/jellyfin-tizen.git" \
+    "$TIZEN_BRANCH" \
+    "jellyfin-tizen"
+
+# ── Build jellyfin-web ─────────────────────────────────────────────────────
+log "Building jellyfin-web…"
+cd jellyfin-web
+npm_install
+USE_SYSTEM_FONTS=1 npm run build:production
+cd ..
+
+# ── Prepare jellyfin-tizen interface ──────────────────────────────────────
+log "Preparing jellyfin-tizen interface…"
+cd jellyfin-tizen
+npm_install "JELLYFIN_WEB_DIR=../jellyfin-web/dist"
+
+# ── Build WGT ─────────────────────────────────────────────────────────────
+log "Running tizen build-web…"
+tizen build-web \
+    -e ".*" \
+    -e gulpfile.babel.js \
+    -e README.md \
+    -e "node_modules/*" \
+    -e "package*.json" \
+    -e "yarn.lock"
+
+log "Signing and packaging WGT…"
+tizen package -t wgt -s "$CERT_PROFILE" -o . -- .buildResult || {
+    echo ""
+    echo "  ERROR: tizen package failed. CLI log:"
+    echo "  ─────────────────────────────────────"
+    cat /home/builder/tizen-studio-data/cli/logs/cli.log 2>/dev/null || echo "  (log not found)"
+    exit 1
+}
+
+# ── Copy output ───────────────────────────────────────────────────────────
+WGT="$(find . -maxdepth 1 -name "*.wgt" | head -1)"
+[ -n "$WGT" ] || die "No .wgt file produced."
+
+mkdir -p "$OUTPUT_DIR"
+cp "$WGT" "$OUTPUT_DIR/Jellyfin.wgt"
+
+echo ""
+echo "════════════════════════════════════════════════════════════"
+echo "  DONE — output/Jellyfin.wgt is ready"
+echo "════════════════════════════════════════════════════════════"
+echo ""

--- a/docker/create-certs.sh
+++ b/docker/create-certs.sh
@@ -1,0 +1,334 @@
+#!/bin/bash
+# ─────────────────────────────────────────────────────────────────────────────
+# create-certs.sh — Samsung Certificate Creator (browser-based GUI via noVNC)
+#
+# Usage:
+#   mkdir -p certs cache data
+#   docker run -it --rm \
+#     -e TV_DUID="YOUR_TV_DUID" \
+#     -p 6080:6080 \
+#     -v ./certs:/certs \
+#     -v ./cache:/cache \
+#     -v ./data:/home/builder/tizen-studio-data \
+#     jellyfin-tizen /create-certs.sh
+#
+# ./cache  — caches the 663 MB installer so the download is skipped next run.
+# ./data   — persists keystore/profiles across runs.
+# No ./sdk volume needed — the IDE installs fresh each run (fast after download).
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+# TV_DUID may be a single ID or a comma-separated list for multiple TVs:
+#   -e TV_DUID="DUID1"
+#   -e TV_DUID="DUID1,DUID2,DUID3"
+TV_DUID="${TV_DUID:?ERROR: set -e TV_DUID=YOUR_TV_DUID  (comma-separate multiple DUIDs)}"
+
+NOVNC_PORT="${NOVNC_PORT:-6080}"
+TIZEN_VERSION="${TIZEN_VERSION:-6.0}"
+export DISPLAY=:1
+SDK_ROOT=""  # populated after IDE install; used by find_in_sdk
+
+# Write DUIDs to /certs/duids.txt immediately so it's available even if the
+# run doesn't complete (e.g. user needs to reference them during the wizard).
+mkdir -p /certs
+{
+    printf '# DUIDs for distributor cert — generated %s\n' "$(date -u '+%Y-%m-%d %H:%M UTC')"
+    echo "$TV_DUID" | tr ',' '\n' | sed 's/^[[:space:]]*//' | grep -v '^$'
+} > /certs/duids.txt
+echo "==> DUIDs saved to ./certs/duids.txt"
+
+find_bin() {
+    local result
+    result=$(find /home/builder -maxdepth 8 -name "$1" 2>/dev/null | head -1)
+    echo "$result"
+}
+
+find_in_sdk() {
+    # Search within the detected SDK root, fall back to all of /home/builder
+    local result
+    if [ -n "${SDK_ROOT:-}" ]; then
+        result=$(find "$SDK_ROOT" -maxdepth 6 -name "$1" 2>/dev/null | head -1)
+    fi
+    if [ -z "$result" ]; then
+        result=$(find /home/builder -maxdepth 8 -name "$1" 2>/dev/null | head -1)
+    fi
+    echo "$result"
+}
+
+# ── Step 1: Start virtual display + window manager ───────────────────────────
+echo "==> Starting virtual display..."
+Xvfb :1 -screen 0 1280x900x24 -nolisten tcp &
+sleep 2
+fluxbox &
+sleep 1
+
+# ── Step 2: Start VNC + noVNC early so user can connect ──────────────────────
+x11vnc -display :1 -forever -nopw -quiet -bg
+sleep 1
+websockify --web=/usr/share/novnc "$NOVNC_PORT" localhost:5900 &
+sleep 1
+
+echo ""
+echo "════════════════════════════════════════════════════════════"
+echo ""
+echo "  Open this URL in your browser NOW:"
+echo ""
+echo "       http://localhost:$NOVNC_PORT/vnc.html"
+echo ""
+echo "  All GUI interaction happens in the browser."
+echo "════════════════════════════════════════════════════════════"
+echo ""
+
+# ── Step 3: Obtain the installer binary (from cache or download) ─────────────
+INSTALLER_URL="https://download.tizen.org/sdk/Installer/tizen-studio_${TIZEN_VERSION}/web-ide_Tizen_Studio_${TIZEN_VERSION}_ubuntu-64.bin"
+CACHE_BIN="/cache/web-ide_Tizen_Studio_${TIZEN_VERSION}_ubuntu-64.bin"
+
+if [ -f "$CACHE_BIN" ]; then
+    echo "==> Using cached installer: $CACHE_BIN"
+    cp "$CACHE_BIN" /tmp/tizen-ide.bin
+else
+    echo "==> Downloading Tizen Studio IDE (~663 MB)..."
+    echo "    Will be saved to ./cache — next run skips this download."
+    echo ""
+    mkdir -p /cache
+    wget -nv "$INSTALLER_URL" -O /tmp/tizen-ide.bin 2>&1
+    cp /tmp/tizen-ide.bin "$CACHE_BIN" 2>/dev/null \
+        && echo "==> Installer saved to cache." \
+        || echo "    (cache save failed — ./cache may not be mounted, will re-download next run)"
+fi
+chmod +x /tmp/tizen-ide.bin
+
+# ── Step 4: Run the installer ────────────────────────────────────────────────
+echo ""
+echo "  ┌───────────────────────────────────────────────────────────┐"
+echo "  │  The Tizen Studio INSTALLER is open in your browser.     │"
+echo "  │                                                           │"
+echo "  │  1. Accept license → Next                                │"
+echo "  │  2. Keep the default path: /home/builder/tizen-studio    │"
+echo "  │     → click Install                                       │"
+echo "  │  3. Wait for the progress bar to finish                  │"
+echo "  │  4. UNCHECK 'Launch Package Manager' → click Finish      │"
+echo "  │                                                           │"
+echo "  │  After Finish the installer closes — wait a few seconds. │"
+echo "  └───────────────────────────────────────────────────────────┘"
+echo ""
+
+/tmp/tizen-ide.bin &
+
+# Poll for sdk.info in the IDE install dir. The web-CLI also creates sdk.info
+# at /home/builder/tizen-studio/sdk.info, so we exclude it by checking that
+# the result is NOT /home/builder/tizen-studio (the pre-existing web-cli path).
+# The IDE installer writes a NEW sdk.info in whichever path the user chose.
+echo "==> Waiting for IDE installation to complete..."
+INSTALL_START=$(date +%s)
+LAST_LOG=0
+while true; do
+    elapsed=$(( $(date +%s) - INSTALL_START ))
+    # Find sdk.info files, skip the one already there from web-cli (tizen-studio)
+    FOUND=$(find /home/builder -maxdepth 3 -name "sdk.info" 2>/dev/null \
+        | grep -v "^/home/builder/tizen-studio/sdk.info$" \
+        | grep -v "tools/sdk.info" | head -1)
+    if [ -n "$FOUND" ]; then
+        SDK_ROOT=$(dirname "$FOUND")
+        echo "    ✓ IDE installed after ${elapsed}s  (SDK at $SDK_ROOT)"
+        break
+    fi
+    # Also detect if user installed to the default path (tizen-studio) by
+    # checking for ide/ subdir (only web-IDE creates it there)
+    if [ -d "/home/builder/tizen-studio/ide" ]; then
+        SDK_ROOT="/home/builder/tizen-studio"
+        echo "    ✓ IDE installed to default path after ${elapsed}s"
+        break
+    fi
+    if [ $elapsed -ge 900 ]; then
+        echo "    ✗ TIMEOUT after ${elapsed}s"
+        echo "  Contents of /home/builder/:"
+        ls /home/builder/ 2>/dev/null
+        echo "  VNC is still running. Press Ctrl+C to abort."
+        sleep infinity
+    fi
+    if [ $(( elapsed - LAST_LOG )) -ge 15 ]; then
+        echo "    ... still installing (${elapsed}s elapsed)"
+        LAST_LOG=$elapsed
+    fi
+    sleep 3
+done
+rm -f /tmp/tizen-ide.bin
+
+# Find the IDE binary relative to the detected SDK root
+IDE_BIN=$(find_in_sdk "TizenStudio")
+[ -z "$IDE_BIN" ] && IDE_BIN=$(find_in_sdk "TizenStudio.sh")
+[ -z "$IDE_BIN" ] && IDE_BIN=$(find "$SDK_ROOT/ide" -maxdepth 3 -name "eclipse" 2>/dev/null | head -1 || true)
+echo "==> SDK_ROOT: $SDK_ROOT"
+echo "==> IDE_BIN:  ${IDE_BIN:-(not found)}"
+
+# ── Step 5: Install cert-add-on + TV-6.0 (first run only) ───────────────────
+CERT_JAR=$(find /home/builder -name "org.tizen.common.cert_*.jar" 2>/dev/null | head -1 || true)
+if [ -z "$CERT_JAR" ]; then
+    PKG_MGR=$(find_in_sdk "package-manager-cli.bin")
+    if [ -n "$PKG_MGR" ]; then
+        echo "==> Installing cert-add-on + TV-6.0 extensions..."
+        "$PKG_MGR" install --accept-license cert-add-on TV-6.0 2>&1 \
+            || "$PKG_MGR" install --accept-license cert-add-on 2>&1 \
+            || echo "WARNING: package install returned non-zero"
+        CERT_JAR=$(find /home/builder -name "org.tizen.common.cert_*.jar" 2>/dev/null | head -1 || true)
+        [ -n "$CERT_JAR" ] && echo "==> cert-add-on ready: $CERT_JAR" \
+            || echo "WARNING: cert-add-on jar not found after install"
+    else
+        echo "WARNING: package-manager-cli.bin not found — cert-add-on skipped"
+    fi
+else
+    echo "==> cert-add-on already installed: $CERT_JAR"
+fi
+
+# ── Step 6: Launch Certificate Manager or full IDE ───────────────────────────
+# cert-add-on installs Certificate Manager as an Eclipse RCP app under
+# tools/certificate-manager/. Find the first executable binary there.
+CERT_MGR_DIR=$(find /home/builder -type d -name "certificate-manager" \
+    -not -path "*/plugins/*" 2>/dev/null | head -1 || true)
+CERT_MGR_BIN=""
+if [ -n "$CERT_MGR_DIR" ]; then
+    echo "==> Certificate Manager dir: $CERT_MGR_DIR"
+    echo "    Contents: $(ls "$CERT_MGR_DIR" 2>/dev/null | tr '\n' ' ')"
+    # Find first executable file or symlink directly in that dir (not in plugins/)
+    CERT_MGR_BIN=$(find "$CERT_MGR_DIR" -maxdepth 1 \( -type f -o -type l \) -perm /111 2>/dev/null | head -1 || true)
+fi
+
+# Re-confirm IDE_BIN; search in SDK_ROOT/ide/ since that's where the launcher is
+[ -z "${IDE_BIN:-}" ] && IDE_BIN=$(find "${SDK_ROOT}/ide" -maxdepth 2 -name "TizenStudio" 2>/dev/null | head -1 || true)
+[ -z "${IDE_BIN:-}" ] && IDE_BIN=$(find "${SDK_ROOT}/ide" -maxdepth 2 -name "eclipse" 2>/dev/null | head -1 || true)
+[ -z "${IDE_BIN:-}" ] && IDE_BIN=$(find /home/builder -maxdepth 8 -name "TizenStudio" 2>/dev/null | head -1 || true)
+
+echo "==> SDK_ROOT:     $SDK_ROOT"
+echo "==> IDE_BIN:      ${IDE_BIN:-(not found)}"
+echo "==> CERT_MGR_BIN: ${CERT_MGR_BIN:-(not found)}"
+
+if [ -n "$CERT_MGR_BIN" ]; then
+    echo "==> Launching Certificate Manager: $CERT_MGR_BIN"
+    LAUNCH_BIN="$CERT_MGR_BIN"
+elif [ -n "$IDE_BIN" ]; then
+    echo "==> Launching full Tizen Studio IDE: $IDE_BIN"
+    echo "    In the IDE: Tools → Certificate Manager"
+    LAUNCH_BIN="$IDE_BIN"
+else
+    echo ""
+    echo "  ERROR: Neither Certificate Manager nor TizenStudio binary found."
+    echo "  Contents of /home/builder/:"
+    ls /home/builder/ 2>/dev/null
+    echo "  Contents of SDK_ROOT=${SDK_ROOT:-unknown}/tools/ (if exists):"
+    ls "${SDK_ROOT:-/home/builder/tizen-studio}/tools/" 2>/dev/null || true
+    echo "  VNC is still running — inspect in your browser. Press Ctrl+C to abort."
+    sleep infinity
+fi
+
+"$LAUNCH_BIN" &
+LAUNCH_PID=$!
+
+echo ""
+echo "  ┌─────────────────────────────────────────────────────────┐"
+echo "  │  Certificate Manager is opening in your browser.       │"
+echo "  │                                                         │"
+echo "  │  Click  +  → Samsung → TV  and follow the wizard:      │"
+echo "  │    1. Create author cert → sign in with Samsung account │"
+echo "  │    2. Create distributor cert → enter the DUID(s) below │"
+echo "  │                                                         │"
+echo "  │  When finished, certs are copied automatically.        │"
+echo "  └─────────────────────────────────────────────────────────┘"
+echo ""
+echo "  TV DUID(s) — enter each in the distributor cert wizard:"
+echo "$TV_DUID" | tr ',' '\n' | sed 's/^[[:space:]]*//' | grep -v '^$' | \
+    while IFS= read -r duid; do echo "    • $duid"; done
+echo ""
+
+# ── Step 7: Watch for .p12 files ─────────────────────────────────────────────
+chmod 777 /certs 2>/dev/null || true
+mkdir -p /certs
+
+# Helper: find any .p12 matching *author* or *Author* under /home/builder
+find_p12() {
+    local pattern="$1"
+    find /home/builder /certs -iname "${pattern}.p12" 2>/dev/null \
+        | grep -v "^/certs/" | head -1 || true
+}
+
+echo "==> Watching for certificates (polling every 3s, no timeout)..."
+echo "    Searching under /home/builder for any *.p12 files..."
+WATCH_START=$(date +%s)
+LAST_WATCH_LOG=0
+WARNED=0
+while true; do
+    # Search directly by exact filename first (most reliable)
+    AUTHOR=$(find /home/builder -name "author.p12"      2>/dev/null | head -1 || true)
+    DIST=$(  find /home/builder -name "distributor.p12" 2>/dev/null | head -1 || true)
+
+    # Fallback: any .p12 classified by path keyword
+    if [ -z "$AUTHOR" ] || [ -z "$DIST" ]; then
+        ALL_P12=$(find /home/builder -name "*.p12" 2>/dev/null || true)
+        [ -z "$AUTHOR" ] && AUTHOR=$(echo "$ALL_P12" | grep -i "author"      | head -1 || true)
+        [ -z "$DIST"   ] && DIST=$(  echo "$ALL_P12" | grep -i "distributor" | head -1 || true)
+        # Last resort: take first two .p12 files found
+        if [ -z "$AUTHOR" ] && [ -z "$DIST" ] && [ -n "$ALL_P12" ]; then
+            AUTHOR=$(echo "$ALL_P12" | sed -n '1p')
+            DIST=$(  echo "$ALL_P12" | sed -n '2p')
+        fi
+    fi
+
+    if [ -n "$AUTHOR" ] && [ -n "$DIST" ]; then
+        echo ""
+        echo "==> Certificates found — copying to /certs..."
+        echo "    author:      $AUTHOR"
+        echo "    distributor: $DIST"
+        cp "$AUTHOR" /certs/author.p12
+        cp "$DIST"   /certs/distributor.p12
+        # Save DUIDs used for this cert to certs/duids.txt
+        printf '%s\n' "# DUIDs used to generate distributor cert on $(date -u '+%Y-%m-%d %H:%M UTC')" > /certs/duids.txt
+        echo "$TV_DUID" | tr ',' '\n' | sed 's/^[[:space:]]*//' | grep -v '^$' >> /certs/duids.txt
+        # Backup entire SamsungCertificate directory
+        if [ -d "/home/builder/SamsungCertificate" ]; then
+            echo "==> Backing up ~/SamsungCertificate to /certs/SamsungCertificate/..."
+            cp -r /home/builder/SamsungCertificate /certs/SamsungCertificate
+        fi
+        # Backup tizen-studio-data keystore (profiles + keystores)
+        if [ -d "/home/builder/tizen-studio-data/keystore" ]; then
+            echo "==> Backing up tizen-studio-data/keystore to /certs/keystore/..."
+            cp -r /home/builder/tizen-studio-data/keystore /certs/keystore
+        fi
+        if [ -d "/home/builder/tizen-studio-data/profile" ]; then
+            echo "==> Backing up tizen-studio-data/profile to /certs/profile/..."
+            cp -r /home/builder/tizen-studio-data/profile /certs/profile
+        fi
+        echo ""
+        echo "════════════════════════════════════════════════════════════"
+        echo "  DONE"
+        echo "  certs/author.p12"
+        echo "  certs/distributor.p12"
+        echo "  certs/duids.txt            (DUIDs used)"
+        echo "  certs/SamsungCertificate/  (full backup)"
+        echo "  certs/keystore/            (tizen keystore backup)"
+        echo ""
+        echo "  Next: docker run ... jellyfin-tizen /build-wgt.sh"
+        echo "════════════════════════════════════════════════════════════"
+        echo ""
+        kill $LAUNCH_PID 2>/dev/null || true
+        break
+    elif [ -n "$AUTHOR" ]; then
+        echo "    ... author cert found, still waiting for distributor cert..."
+    fi
+
+    elapsed=$(( $(date +%s) - WATCH_START ))
+    if [ $elapsed -ge 600 ] && [ $WARNED -eq 0 ]; then
+        WARNED=1
+        echo ""
+        echo "  NOTE: 10 minutes elapsed — still watching."
+        echo "  .p12 files currently found under /home/builder:"
+        find /home/builder -name "*.p12" 2>/dev/null || echo "    (none yet)"
+        echo "  Take your time — complete the wizard then click Finish."
+        echo ""
+    fi
+    if [ $(( elapsed - LAST_WATCH_LOG )) -ge 30 ] && [ $elapsed -gt 5 ]; then
+        echo "    ... waiting for Certificate Manager wizard to complete (${elapsed}s)"
+        LAST_WATCH_LOG=$elapsed
+    fi
+    sleep 3
+done
+

--- a/docker/install-wgt.sh
+++ b/docker/install-wgt.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# ─────────────────────────────────────────────────────────────────────────────
+# install-wgt.sh — Connect to a Samsung TV in developer mode and install WGT
+#
+# Usage:
+#   docker run --rm --network host \
+#     -e TV_IP="192.168.1.100" \
+#     -v "$(pwd)/output:/output" \
+#     jellyfin-tizen /install-wgt.sh
+#
+# Required env vars:
+#   TV_IP      — TV IP address (also accepted as TV_HOST)
+#
+# Optional env vars:
+#   TV_PORT    — SDB port on the TV (default: 26101)
+#   WGT_FILE   — path inside the container to the .wgt (default: /output/Jellyfin.wgt)
+#   CONNECT_TIMEOUT — seconds to wait for sdb 'device' state (default: 15)
+#
+# TV prerequisites (Samsung):
+#   Apps → 12345 on remote → Enable Developer Mode → enter this machine's IP → reboot TV
+#   Developer mode must be re-enabled after every TV power cycle.
+#
+# Networking:
+#   Requires --network host on a LINUX host to reach LAN devices.
+#   macOS Docker Desktop runs containers inside a LinuxKit VM — VPNKit does not
+#   proxy RFC1918 LAN traffic from the VM to the Mac's NIC, so the container
+#   cannot reach a TV on the LAN regardless of --network host.
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+TV_IP="${TV_IP:-${TV_HOST:-}}"
+TV_PORT="${TV_PORT:-26101}"
+WGT_FILE="${WGT_FILE:-/output/Jellyfin.wgt}"
+CONNECT_TIMEOUT="${CONNECT_TIMEOUT:-15}"
+
+log()  { echo ""; echo "==> $*"; }
+die()  { echo ""; echo "ERROR: $*" >&2; exit 1; }
+warn() { echo "WARN: $*" >&2; }
+
+[ -n "$TV_IP"    ] || die "TV_IP is not set. Pass it with: -e TV_IP=<your-tv-ip>"
+[ -f "$WGT_FILE" ] || die "WGT file not found: $WGT_FILE (mount your output dir with -v)"
+
+echo ""
+echo "════════════════════════════════════════════════════════════"
+echo "  Jellyfin Tizen — Step 3: Install on TV"
+echo "════════════════════════════════════════════════════════════"
+echo "  TV address  : ${TV_IP}:${TV_PORT}"
+echo "  WGT file    : $WGT_FILE"
+echo "  Timeout     : ${CONNECT_TIMEOUT}s"
+echo "════════════════════════════════════════════════════════════"
+
+# ── Connect via sdb ───────────────────────────────────────────────────────────
+log "Connecting via sdb …"
+sdb kill-server 2>/dev/null || true
+sleep 1
+CONNECT_OUT=$(sdb connect "${TV_IP}:${TV_PORT}" 2>&1)
+echo "    $CONNECT_OUT"
+
+if echo "$CONNECT_OUT" | grep -qi "error\|failed"; then
+    echo ""
+    echo "  ERROR: sdb connect failed: $CONNECT_OUT"
+    echo ""
+    echo "  On Linux hosts: ensure developer mode is active on the TV:"
+    echo "    Apps → 12345 → Enable Developer Mode → enter host LAN IP → reboot TV"
+    echo "  On macOS Docker Desktop: containers cannot reach LAN devices even with"
+    echo "    --network host (VPNKit VM limitation). Run tizen install natively or"
+    echo "    use a Linux host."
+    exit 1
+fi
+
+# ── Wait for 'device' state ───────────────────────────────────────────────────
+log "Waiting for TV to be ready (up to ${CONNECT_TIMEOUT}s) …"
+WAITED=0
+STATE=""
+while [ "$WAITED" -lt "$CONNECT_TIMEOUT" ]; do
+    STATE=$(sdb devices 2>/dev/null | awk -v ip="${TV_IP}:${TV_PORT}" '$0 ~ ip { print $2 }')
+    case "$STATE" in
+        device)   break ;;
+        offline)  warn "Device shows 'offline' — still waiting …" ;;
+        locked)   warn "Device shows 'locked' — still waiting …" ;;
+    esac
+    sleep 1
+    WAITED=$((WAITED + 1))
+done
+
+if [ "$STATE" != "device" ]; then
+    echo ""
+    echo "  ERROR: TV did not reach 'device' state after ${CONNECT_TIMEOUT}s (last state: '${STATE:-none}')."
+    echo ""
+    sdb devices 2>/dev/null || true
+    echo ""
+    echo "  If state is 'offline': the TV accepted the connection but sdb handshake failed."
+    echo "    → Check the IP entered in Developer Mode matches this machine's LAN IP."
+    echo "  If state is empty: sdb could not connect at all."
+    echo "    → Verify TCP connectivity: port ${TV_PORT} must be reachable."
+    exit 1
+fi
+
+log "Connected. Devices:"
+sdb devices
+
+# ── Determine serial ──────────────────────────────────────────────────────────
+SERIAL=$(sdb devices 2>/dev/null | awk -v ip="${TV_IP}:${TV_PORT}" '$0 ~ ip { print $1 }' | head -1)
+[ -n "$SERIAL" ] || die "Could not determine sdb serial for ${TV_IP}"
+echo "    Serial: $SERIAL"
+
+# ── Install ───────────────────────────────────────────────────────────────────
+log "Installing $(basename "$WGT_FILE") …"
+tizen install -n "$WGT_FILE" -s "$SERIAL" 2>&1
+
+echo ""
+echo "════════════════════════════════════════════════════════════"
+echo "  DONE — Jellyfin installed on ${TV_IP}"
+echo "════════════════════════════════════════════════════════════"
+echo ""

--- a/docker/secret-tool.sh
+++ b/docker/secret-tool.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Tizen Studio secret-tool replacement — file-based storage, no D-Bus required.
+#
+# LinuxCrypt.java (org.tizen.common.sign) calls this binary to store and
+# retrieve .p12 passwords keyed by the path written into profiles.xml.
+# The real GNOME secret-tool requires dbus-launch + a running keyring daemon,
+# which is unavailable in a headless Docker container. This script replaces
+# the bundled binary with a simple file-based implementation.
+#
+# Storage location: /tmp/.tizen_secrets/<path-with-slashes-replaced-by-underscores>
+#   Override with TIZEN_SECRET_STORE env var (useful for testing).
+#
+# Supported commands (matching the bundled tool's CLI):
+#   store  --label LABEL -p PASSWORD keyfile PATH tool certificate-manager
+#   lookup --label LABEL             keyfile PATH tool certificate-manager
+#   clear                            keyfile PATH tool certificate-manager
+
+STORE_DIR="${TIZEN_SECRET_STORE:-/tmp/.tizen_secrets}"
+mkdir -p "$STORE_DIR"
+
+_key_file() { printf '%s' "$1" | tr '/' '_'; }
+
+case "${1:-}" in
+    store)
+        PASSWORD=""
+        KEYFILE=""
+        shift
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -p|--password) PASSWORD="$2"; shift 2 ;;
+                keyfile)       KEYFILE="$2";  shift 2 ;;
+                *)             shift ;;
+            esac
+        done
+        if [[ -n "$KEYFILE" && -n "$PASSWORD" ]]; then
+            printf '%s' "$PASSWORD" > "$STORE_DIR/$(_key_file "$KEYFILE")"
+        fi
+        exit 0
+        ;;
+    lookup)
+        KEYFILE=""
+        shift
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                keyfile) KEYFILE="$2"; shift 2 ;;
+                *)       shift ;;
+            esac
+        done
+        if [[ -n "$KEYFILE" ]]; then
+            F="$STORE_DIR/$(_key_file "$KEYFILE")"
+            [[ -f "$F" ]] && cat "$F" && exit 0
+        fi
+        exit 1
+        ;;
+    clear)
+        exit 0
+        ;;
+    *)
+        echo "secret-tool: unknown command: ${1:-}" >&2
+        exit 1
+        ;;
+esac

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -92,7 +91,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -427,7 +425,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.5.tgz",
       "integrity": "sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/template": "^7.24.0",
         "@babel/traverse": "^7.24.5",
@@ -2462,6 +2459,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -3310,7 +3308,6 @@
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -4205,7 +4202,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -5111,6 +5107,7 @@
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -6167,7 +6164,6 @@
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -6217,8 +6213,7 @@
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -6452,7 +6447,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.5.tgz",
       "integrity": "sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/template": "^7.24.0",
         "@babel/traverse": "^7.24.5",
@@ -7800,6 +7794,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
       "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -8456,8 +8451,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -9149,8 +9143,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.2",
@@ -9872,6 +9865,7 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",


### PR DESCRIPTION
## Add fully Docker-based Samsung cert creator and WGT builder

This adds a self-contained Docker toolchain for building and installing `Jellyfin.wgt` on Samsung
Tizen TVs — **no host tools required** beyond Docker itself.

### What's included

| File | Purpose |
|---|---|
| `Dockerfile` | Single image with Tizen Studio web-CLI, Node.js 20, virtual display, VNC/noVNC, and Chrome |
| `create-certs.sh` | Launches a browser-based GUI (noVNC on port 6080) to create Samsung author + distributor certificates tied to your TV's DUID |
| `build-wgt.sh` | Clones `jellyfin-web` + `jellyfin-tizen`, builds them, signs and packages `Jellyfin.wgt` |
| `install-wgt.sh` | Connects to a Samsung TV via SDB and installs the `.wgt` |
| `secret-tool.sh` | Drop-in replacement for GNOME `secret-tool` using file-based storage — makes cert signing work in headless containers |
| `README.md` | Full step-by-step guide |

### Motivation

Setting up Tizen Studio, the certificate manager, and the signing toolchain natively is error-prone
and platform-dependent. This image encapsulates the entire workflow into three commands:

1. `docker build` — one time
2. `docker run ... /create-certs.sh` — one time, opens browser UI on `localhost:6080`
3. `docker run ... /build-wgt.sh` — produces `output/Jellyfin.wgt`

Build caches (`node_modules`, git repos) are persisted in a bind-mounted volume so subsequent
builds are fast.