### PR TITLE
Suppress screen saver during media playback

### DIFF
--- a/tizen.js
+++ b/tizen.js
@@ -111,6 +111,16 @@
 
             exit: function () {
                 postMessage('AppHost.exit');
+
+                // Re-enable the screen saver before exiting
+                try {
+                    webapis.appcommon.setScreenSaver(
+                        webapis.appcommon.AppCommonScreenSaverState.SCREEN_SAVER_ON
+                    );
+                } catch (e) {
+                    // Ignore errors during exit
+                }
+
                 tizen.application.getCurrentApplication().exit();
             },
 
@@ -172,10 +182,40 @@
 
         updateMediaSession: function (mediaInfo) {
             postMessage('updateMediaSession', { mediaInfo: mediaInfo });
+
+            // Suppress the Samsung screen saver during active playback
+            try {
+                webapis.appcommon.setScreenSaver(
+                    webapis.appcommon.AppCommonScreenSaverState.SCREEN_SAVER_OFF,
+                    function (result) {
+                        postMessage('setScreenSaver', { state: 'OFF', result: result });
+                    },
+                    function (error) {
+                        postMessage('setScreenSaver', { state: 'OFF', error: JSON.stringify(error) });
+                    }
+                );
+            } catch (e) {
+                postMessage('setScreenSaver', { error: e.message });
+            }
         },
 
         hideMediaSession: function () {
             postMessage('hideMediaSession');
+
+            // Re-enable the Samsung screen saver when playback stops
+            try {
+                webapis.appcommon.setScreenSaver(
+                    webapis.appcommon.AppCommonScreenSaverState.SCREEN_SAVER_ON,
+                    function (result) {
+                        postMessage('setScreenSaver', { state: 'ON', result: result });
+                    },
+                    function (error) {
+                        postMessage('setScreenSaver', { state: 'ON', error: JSON.stringify(error) });
+                    }
+                );
+            } catch (e) {
+                postMessage('setScreenSaver', { error: e.message });
+            }
         }
     };
 


### PR DESCRIPTION
## Summary

Calls the Samsung AppCommon API (`webapis.appcommon.setScreenSaver`) to disable the TV's screen saver during active media playback. This fixes the long-standing issue where the Samsung TV's screen saver activates during audio-only playback (e.g. music), because the TV treats the lack of video activity as idle.

### Changes

- **`updateMediaSession`**: Disables the screen saver (`SCREEN_SAVER_OFF`) when playback starts or updates
- **`hideMediaSession`**: Re-enables the screen saver (`SCREEN_SAVER_ON`) when playback stops
- **`exit`**: Re-enables the screen saver before the app exits as a safety net

All calls are wrapped in try/catch to handle TVs where the API may not be available. No additional privileges are required in `config.xml` — the AppCommon API is part of the base Samsung Product API.

### Samsung API Reference

- [Setting Screensaver](https://developer.samsung.com/smarttv/develop/guides/fundamentals/setting-screensaver.html)
- [AppCommon API](https://developer.samsung.com/smarttv/develop/api-references/samsung-product-api-references/appcommon-api.html)

Fixes #141

## Test plan

- [ ] Play a video — screen saver should not activate during playback (existing behavior preserved)
- [ ] Play audio-only content (music) — screen saver should no longer activate
- [ ] Stop playback — screen saver should resume normal behavior
- [ ] Exit the app during playback — screen saver should be re-enabled
- [ ] Test on older Tizen models to verify graceful fallback (try/catch)