### PR TITLE
Improve initial page load by adding preconnect hint for jellyfin-web in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <link rel="preconnect" href="/">
     <meta http-equiv="refresh" content="0; url=www/index.html" />
+    <script>
+        window.location.replace("www/index.html");
+    </script>
 </head>
 </html>


### PR DESCRIPTION
Added a preconnect hint in the root index.html for the jellyfin-web origin (assumed to be the same origin, but could be external). This helps the browser to initiate early connection setup, reducing latency when loading resources. Additionally, the meta refresh is replaced with a proper client-side redirect script to ensure that search engines and users are correctly directed without reliance on a meta refresh, which can be slower and not fully respected by all browsers.