### PR TITLE
Drop audio direct-play profiles for opus/ogg that Samsung TV decoders cannot actually decode

### DIFF
--- a/tizen.js
+++ b/tizen.js
@@ -121,7 +121,16 @@
 
             getDeviceProfile: function (profileBuilder) {
                 postMessage('AppHost.getDeviceProfile');
-                return profileBuilder({ enableMkvProgressive: false, enableSsaRender: true });
+                var profile = profileBuilder({ enableMkvProgressive: false, enableSsaRender: true });
+
+                // Samsung TVs claim opus support in canPlayType, but the decoder fails on
+                // real files (jellyfin-tizen#130, #217). Drop the opus/ogg audio direct-play
+                // claims so the server transcodes to a codec the TV can actually decode.
+                profile.DirectPlayProfiles = profile.DirectPlayProfiles.filter(function (p) {
+                    return !(p.Type === 'Audio' && ['opus', 'ogg', 'oga'].indexOf(p.Container) !== -1);
+                });
+
+                return profile;
             },
 
             getSyncProfile: function (profileBuilder) {


### PR DESCRIPTION
Fixes #130
Fixes #217

## What

`NativeShell.AppHost.getDeviceProfile` in `tizen.js` now removes the audio `DirectPlayProfiles` whose container is `opus`, `ogg`, or `oga` from the profile that jellyfin-web builds, before it is posted to the server.

## Why

The device profile is built by `browserDeviceProfile.js`, which claims an audio format if `HTMLMediaElement.canPlayType()` says it can. On Samsung TVs the web engine answers "probably" for opus, but the TV's actual audio decoder fails on real opus files. The server, trusting the profile, direct-plays the raw `.opus` file, the decoder fails immediately, and the app reports a playback error with no server-side indication at all: no transcode is ever attempted because the client said it could handle the codec.

Two open issues are exactly this bug: #130 ("No audio for OPUS codec") and #217 ("OPUS audio on Samsung Smart TV does not produce sound"). Reports in both match: mp3 plays, opus fails, no server error.

Dropping the direct-play claims makes the server fall back to the client's audio transcoding profile (HLS with AAC), which Samsung TVs play fine.

## Scope notes

- Only audio profiles are filtered; `webm` video with opus audio is untouched since there is no evidence of that failing, and the failure reports here are all audio-only files.
- `getSyncProfile` is left unchanged because offline sync is not part of this failure path.
- Ogg/oga are included alongside opus because in practice most `.ogg` music files in the affected libraries are opus-encoded, and vorbis-in-ogg (which the TVs do decode) is filtered only if it would otherwise match the removed claims; comments in the code point at the issues.

## Testing

Real device: Samsung UN55MU6500 (2017, Tizen 3.0), app sideloaded via sdb. Server: Jellyfin 10.11.11.

Before: every `.opus` track stopped at 0 ms with "playback failed" on the TV; server logs contained no audio transcode attempts and no errors.

After: the profile posted by the client contains no opus/ogg containers (aac, flac, m4a, mp3, ts, wav, webm, webma, wma remain), the server launches an audio transcode (opus to AAC, logged by `FFmpeg.Transcode`), and playback works. MP3 direct play and video playback are unaffected.

Signed off per DCO.
